### PR TITLE
Fix tag sorting direction

### DIFF
--- a/src/main/kotlin/org/snd/metadata/anilist/AniListMetadataMapper.kt
+++ b/src/main/kotlin/org/snd/metadata/anilist/AniListMetadataMapper.kt
@@ -62,9 +62,9 @@ class AniListMetadataMapper {
             ?.mapNotNull { if (it.rank == null) null else it.name to it.rank } ?: emptyList()
 
         val tags = if (allTags.size <= 15) {
-            allTags.sortedBy { it.second }.map { it.first }
+            allTags.sortedByDescending { it.second }.map { it.first }
         } else if (allTags.count { it.second > 70 } <= 15) {
-            allTags.sortedBy { it.second }.take(15).map { it.first }
+            allTags.sortedByDescending { it.second }.take(15).map { it.first }
         } else {
             allTags.filter { it.second > 70 }.map { it.first }
         }


### PR DESCRIPTION
The tag mapper was taking the 15 *worst* tags rather than the 15 *best*. This fixes that.