### PR TITLE
Add MangaDex content ratings

### DIFF
--- a/src/main/kotlin/org/snd/metadata/providers/mangadex/MangaDexClient.kt
+++ b/src/main/kotlin/org/snd/metadata/providers/mangadex/MangaDexClient.kt
@@ -35,6 +35,10 @@ class MangaDexClient(
                 .addQueryParameter("includes[]", "author")
                 .addQueryParameter("includes[]", "cover_art")
                 .addQueryParameter("order[relevance]", "desc")
+                .addQueryParameter("contentRating[]", "safe")
+                .addQueryParameter("contentRating[]", "suggestive")
+                .addQueryParameter("contentRating[]", "erotica")
+                .addQueryParameter("contentRating[]", "pornographic")
 
                 .addQueryParameter("title", title)
                 .build()


### PR DESCRIPTION
Added all content ratings to the MangaDex series search.

(by default, MangaDex includes 3 out of 4 content ratings when searching)