### PR TITLE
Remove bookwalker restriction

### DIFF
--- a/src/main/kotlin/org/snd/metadata/providers/bookwalker/BookWalkerClient.kt
+++ b/src/main/kotlin/org/snd/metadata/providers/bookwalker/BookWalkerClient.kt
@@ -28,7 +28,8 @@ class BookWalkerClient(
                 .addQueryParameter("qcat", category.number.toString())
                 .addQueryParameter("np", "0")
                 .build()
-        ).build()
+        ).addHeader("Cookie", "safeSearch=111; glSafeSearch=1")
+        .build()
 
         return try {
             parser.parseSearchResults(client.execute(request))

--- a/src/main/kotlin/org/snd/metadata/providers/bookwalker/BookWalkerClient.kt
+++ b/src/main/kotlin/org/snd/metadata/providers/bookwalker/BookWalkerClient.kt
@@ -44,7 +44,8 @@ class BookWalkerClient(
             baseUrl.newBuilder().addPathSegments("series/${id.id}")
                 .addQueryParameter("page", page.toString())
                 .build()
-        ).build()
+        ).addHeader("Cookie", "safeSearch=111; glSafeSearch=1")
+        .build()
 
         return parser.parseSeriesBooks(client.execute(request))
     }
@@ -53,7 +54,8 @@ class BookWalkerClient(
         val request = Request.Builder().url(
             baseUrl.newBuilder().addPathSegments(id.id)
                 .build()
-        ).build()
+        ).addHeader("Cookie", "safeSearch=111; glSafeSearch=1")
+        .build()
 
         return parser.parseBook(client.execute(request))
     }


### PR DESCRIPTION
Bookwalker by default will apply some restrictions for search result (e.g. mature content) this PR add a `Cookie` header that will bypass those restriction