### PR TITLE
Change AniList coverImage to extraLarge instead of large

### DIFF
--- a/src/main/graphql/org/snd/MediaSearch.graphql
+++ b/src/main/graphql/org/snd/MediaSearch.graphql
@@ -12,7 +12,7 @@ fragment aniListManga on Media {
     chapters,
     volumes,
     coverImage {
-        large
+        extraLarge
     },
     startDate {
         year,

--- a/src/main/kotlin/org/snd/metadata/providers/anilist/AniListClient.kt
+++ b/src/main/kotlin/org/snd/metadata/providers/anilist/AniListClient.kt
@@ -68,7 +68,7 @@ class AniListClient(
 
     fun getThumbnail(series: AniListManga): Image? {
         return rateLimited {
-            series.coverImage?.large?.toHttpUrlOrNull()?.let {
+            series.coverImage?.extraLarge?.toHttpUrlOrNull()?.let {
                 val request = Request.Builder().url(it).build()
                 val bytes = okHttpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) throw HttpException(response)

--- a/src/main/kotlin/org/snd/metadata/providers/anilist/AniListMetadataMapper.kt
+++ b/src/main/kotlin/org/snd/metadata/providers/anilist/AniListMetadataMapper.kt
@@ -110,7 +110,7 @@ class AniListMetadataMapper(
     fun toSearchResult(search: AniListManga): SeriesSearchResult {
         val title = search.title?.english ?: search.title?.romaji ?: search.title?.native
         return SeriesSearchResult(
-            imageUrl = search.coverImage?.large,
+            imageUrl = search.coverImage?.extraLarge,
             title = title!!,
             provider = Provider.ANILIST,
             resultId = search.id.toString()


### PR DESCRIPTION
This increases the cover image resolution fetched from anilist. ExtraLarge automatically falls back to large if it doesn't exist so it won't break anything. I found that for most of my manga's, large was around 230x326 pixels which is quite small compared to the actual resolution on anilist which was around 2x that at 460x645. This change enables to get the full 460x645 resolution.