### PR TITLE
Add Kavita cover locking config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ kavita:
       bookCovers: false #update book thumbnails
       seriesCovers: false #update series thumbnails
       overrideExistingCovers: true # if false will upload but not select new cover if another cover already exists
+      lockCovers: false # lock cover images so that kavita does not change them
       postProcessing:
         seriesTitle: false #update series title
         seriesTitleLanguage: "en" # series title update language. If empty chose first matching title

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
@@ -46,6 +46,7 @@ data class MetadataProcessingConfigDto(
     val bookCovers: Boolean,
     val seriesCovers: Boolean,
     val overrideExistingCovers: Boolean,
+    val lockCovers: Boolean,
 
     val updateModes: List<KomfUpdateMode>,
     val postProcessing: MetadataPostProcessingConfigDto

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfigUpdateRequest.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfigUpdateRequest.kt
@@ -50,6 +50,7 @@ data class MetadataProcessingConfigUpdateRequest(
     val bookCovers: PatchValue<Boolean> = PatchValue.Unset,
     val seriesCovers: PatchValue<Boolean> = PatchValue.Unset,
     val overrideExistingCovers: PatchValue<Boolean> = PatchValue.Unset,
+    val lockCovers: PatchValue<Boolean> = PatchValue.Unset,
     val updateModes: PatchValue<Collection<KomfUpdateMode>> = PatchValue.Unset,
     val overrideComicInfo: PatchValue<Boolean> = PatchValue.Unset,
 

--- a/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/DeprecatedConfigUpdateMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/DeprecatedConfigUpdateMapper.kt
@@ -117,6 +117,7 @@ class DeprecatedConfigUpdateMapper {
             bookCovers = config.bookCovers,
             seriesCovers = config.seriesCovers,
             overrideExistingCovers = config.overrideExistingCovers,
+            lockCovers = config.lockCovers,
             updateModes = config.updateModes,
             postProcessing = toDto(config.postProcessing),
         )

--- a/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigDto.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigDto.kt
@@ -52,7 +52,7 @@ data class MetadataProcessingConfigDto(
     val bookCovers: Boolean,
     val seriesCovers: Boolean,
     val overrideExistingCovers: Boolean,
-
+    var lockCovers: Boolean,
     val updateModes: List<UpdateMode>,
     val postProcessing: MetadataPostProcessingConfigDto
 

--- a/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigUpdateDto.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigUpdateDto.kt
@@ -60,7 +60,7 @@ data class MetadataProcessingConfigUpdateDto(
     val mergeGenres: Boolean? = null,
     val seriesCovers: Boolean? = null,
     val overrideExistingCovers: Boolean? = null,
-
+    var lockCovers: Boolean? = null,
     val updateModes: List<UpdateMode>? = null,
     val postProcessing: MetadataPostProcessingConfigUpdateDto? = null
 )

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
@@ -91,6 +91,7 @@ class AppConfigMapper {
             bookCovers = config.bookCovers,
             seriesCovers = config.seriesCovers,
             overrideExistingCovers = config.overrideExistingCovers,
+            lockCovers = config.lockCovers,
             updateModes = config.updateModes.map { it.fromUpdateMode() },
             postProcessing = toDto(config.postProcessing),
         )

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigUpdateMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigUpdateMapper.kt
@@ -345,6 +345,7 @@ class AppConfigUpdateMapper {
             bookCovers = patch.bookCovers.getOrNull() ?: config.bookCovers,
             seriesCovers = patch.seriesCovers.getOrNull() ?: config.seriesCovers,
             overrideExistingCovers = patch.overrideExistingCovers.getOrNull() ?: config.overrideExistingCovers,
+            lockCovers = patch.lockCovers.getOrNull() ?: config.lockCovers,
             updateModes = patch.updateModes.getOrNull()?.map { it.toUpdateMode() } ?: config.updateModes,
             postProcessing = patch.postProcessing.getOrNull()
                 ?.let { metadataPostProcessingConfig(config.postProcessing, it) }

--- a/komf-app/src/main/kotlin/snd/komf/app/config/AppConfig.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/config/AppConfig.kt
@@ -74,6 +74,7 @@ data class MetadataProcessingConfig(
     val bookCovers: Boolean = false,
     val seriesCovers: Boolean = false,
     val overrideExistingCovers: Boolean = true,
+    var lockCovers: Boolean = false,
     val updateModes: List<UpdateMode> = listOf(API),
     val overrideComicInfo: Boolean = false,
 

--- a/komf-app/src/main/kotlin/snd/komf/app/module/MediaServerModule.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/module/MediaServerModule.kt
@@ -334,7 +334,8 @@ class MediaServerModule(
             updateModes = config.updateModes.toSet(),
             uploadBookCovers = config.bookCovers,
             uploadSeriesCovers = config.seriesCovers,
-            overrideExistingCovers = config.overrideExistingCovers
+            overrideExistingCovers = config.overrideExistingCovers,
+            lockCovers = config.lockCovers,
         )
     }
 }

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/MediaServerClient.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/MediaServerClient.kt
@@ -36,13 +36,15 @@ interface MediaServerClient {
     suspend fun uploadSeriesThumbnail(
         seriesId: MediaServerSeriesId,
         thumbnail: Image,
-        selected: Boolean = false
+        selected: Boolean = false,
+        lock: Boolean = false
     ): MediaServerSeriesThumbnail?
 
     suspend fun uploadBookThumbnail(
         bookId: MediaServerBookId,
         thumbnail: Image,
-        selected: Boolean = false
+        selected: Boolean = false,
+        lock: Boolean = false
     ): MediaServerBookThumbnail?
 
     suspend fun refreshMetadata(libraryId: MediaServerLibraryId, seriesId: MediaServerSeriesId)

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaClient.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaClient.kt
@@ -143,19 +143,19 @@ class KavitaClient(
         return Image(response.body(), contentType.toString())
     }
 
-    suspend fun uploadSeriesCover(seriesId: KavitaSeriesId, cover: Image) {
+    suspend fun uploadSeriesCover(seriesId: KavitaSeriesId, cover: Image, lockCover: Boolean) {
         val base64Image = Base64.getEncoder().encodeToString(cover.bytes)
         ktor.post("api/upload/series") {
             contentType(ContentType.Application.Json)
-            setBody(KavitaCoverUploadRequest(id = seriesId.value, url = base64Image, lockCover = false))
+            setBody(KavitaCoverUploadRequest(id = seriesId.value, url = base64Image, lockCover))
         }
     }
 
-    suspend fun uploadVolumeCover(volumeId: KavitaVolumeId, cover: Image) {
+    suspend fun uploadVolumeCover(volumeId: KavitaVolumeId, cover: Image, lockCover: Boolean) {
         val base64Image = Base64.getEncoder().encodeToString(cover.bytes)
         ktor.post("api/upload/volume") {
             contentType(ContentType.Application.Json)
-            setBody(KavitaCoverUploadRequest(id = volumeId.value, url = base64Image, lockCover = false))
+            setBody(KavitaCoverUploadRequest(id = volumeId.value, url = base64Image, lockCover))
         }
     }
 

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
@@ -158,19 +158,21 @@ class KavitaMediaServerClientAdapter(private val kavitaClient: KavitaClient) : M
     override suspend fun uploadSeriesThumbnail(
         seriesId: MediaServerSeriesId,
         thumbnail: Image,
-        selected: Boolean
+        selected: Boolean,
+        lock: Boolean
     ): MediaServerSeriesThumbnail? {
-        kavitaClient.uploadSeriesCover(seriesId.toKavitaSeriesId(), thumbnail)
+        kavitaClient.uploadSeriesCover(seriesId.toKavitaSeriesId(), thumbnail, lock)
         return null
     }
 
     override suspend fun uploadBookThumbnail(
         bookId: MediaServerBookId,
         thumbnail: Image,
-        selected: Boolean
+        selected: Boolean,
+        lock: Boolean
     ): MediaServerBookThumbnail? {
         val chapter = kavitaClient.getChapter(bookId.toKavitaChapterId())
-        kavitaClient.uploadVolumeCover(chapter.volumeId, thumbnail)
+        kavitaClient.uploadVolumeCover(chapter.volumeId, thumbnail, lock)
         return null
     }
 

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/komga/KomgaMediaServerClientAdapter.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/komga/KomgaMediaServerClientAdapter.kt
@@ -157,7 +157,8 @@ class KomgaMediaServerClientAdapter(
     override suspend fun uploadSeriesThumbnail(
         seriesId: MediaServerSeriesId,
         thumbnail: Image,
-        selected: Boolean
+        selected: Boolean,
+        lock: Boolean
     ): MediaServerSeriesThumbnail? {
         if (thumbnail.bytes.size > komgaCoverUploadLimit) {
             logger.warn { "Thumbnail size is bigger than $komgaCoverUploadLimit bytes. Skipping thumbnail upload" }
@@ -179,7 +180,7 @@ class KomgaMediaServerClientAdapter(
 
     override suspend fun uploadBookThumbnail(
         bookId: MediaServerBookId,
-        thumbnail: Image, selected: Boolean
+        thumbnail: Image, selected: Boolean, lock: Boolean
     ): MediaServerBookThumbnail? {
         if (thumbnail.bytes.size > komgaCoverUploadLimit) {
             logger.warn { "Thumbnail size is bigger than $komgaCoverUploadLimit bytes. Skipping thumbnail upload" }

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataUpdater.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataUpdater.kt
@@ -34,6 +34,7 @@ class MetadataUpdater(
     private val overrideExistingCovers: Boolean,
     private val uploadBookCovers: Boolean,
     private val uploadSeriesCovers: Boolean,
+    private val lockCovers: Boolean,
 ) {
     private val requireMetadataRefresh = setOf(UpdateMode.COMIC_INFO)
     private val natSortComparator: Comparator<String> = caseInsensitiveNatSortComparator()
@@ -186,7 +187,8 @@ class MetadataUpdater(
             mediaServerClient.uploadSeriesThumbnail(
                 seriesId = seriesId,
                 thumbnail = thumbnail,
-                selected = selectThumbnail
+                selected = selectThumbnail,
+                lock = lockCovers,
             )
         }
 


### PR DESCRIPTION
Closes #166 

First off, please excuse any slop, this was my first time touching this codebase and dealing with Kotlin. I've tested it on my setup and it appears to function as expected.

Adds a new config option `lockCovers` for Kavita; locks the field so that Kavita no longer changes the covers back. Defaults to false to mimic current behaviour.

Some comments in that issue mentioned issues with other metadata fields regressing, but I was unable to replicate it on my client, so I cannot address that in this PR