### PR TITLE
Making role optional

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/model/Author.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/model/Author.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Author(
     val name: String,
-    val role: AuthorRole
+    val role: AuthorRole? = null
 )
 enum class AuthorRole {
     WRITER,


### PR DESCRIPTION
Some titles get this error and make the scan fail:

```java
[DefaultDispatcher-worker-1]` ERROR snd.komf.mediaserver.metadata.MetadataService -- catching
io.ktor.serialization.JsonConvertException: Illegal input: Field 'role' is required for type with serial name 'snd.komf.mediaserver.kavita.model.KavitaAuthor', but it was missing at path: $.writers[0]
	at io.ktor.serialization.kotlinx.KotlinxSerializationConverter.deserialize(KotlinxSerializationConverter.kt:77)
	at io.ktor.serialization.ContentConverterKt$deserialize$$inlined$map$1$2.emit(Emitters.kt:51)
	at kotlinx.coroutines.flow.FlowKt__BuildersKt$asFlow$$inlined$unsafeFlow$3.collect(SafeCollector.common.kt:111)
	at io.ktor.serialization.ContentConverterKt$deserialize$$inlined$map$1.collect(SafeCollector.common.kt:109)
	at kotlinx.coroutines.flow.FlowKt__ReduceKt.firstOrNull(Reduce.kt:239)
	at kotlinx.coroutines.flow.FlowKt.firstOrNull(Unknown Source)
	at io.ktor.serialization.ContentConverterKt.deserialize(ContentConverter.kt:97)
	at io.ktor.client.plugins.contentnegotiation.ContentNegotiationKt.ContentNegotiation$lambda$13$convertResponse(ContentNegotiation.kt:234)
	at io.ktor.client.plugins.contentnegotiation.ContentNegotiationKt.access$ContentNegotiation$lambda$13$convertResponse(ContentNegotiation.kt:1)
	at io.ktor.client.plugins.contentnegotiation.ContentNegotiationKt$ContentNegotiation$2$2.invokeSuspend(ContentNegotiation.kt:249)
	at io.ktor.client.plugins.contentnegotiation.ContentNegotiationKt$ContentNegotiation$2$2.invoke(ContentNegotiation.kt)
	at io.ktor.client.plugins.contentnegotiation.ContentNegotiationKt$ContentNegotiation$2$2.invoke(ContentNegotiation.kt)
	at io.ktor.client.plugins.api.TransformResponseBodyHook$install$1.invokeSuspend(KtorCallContexts.kt:104)
	at io.ktor.client.plugins.api.TransformResponseBodyHook$install$1.invoke(KtorCallContexts.kt)
	at io.ktor.client.plugins.api.TransformResponseBodyHook$install$1.invoke(KtorCallContexts.kt)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.util.pipeline.DebugPipelineContext.proceed(DebugPipelineContext.kt:57)
	at io.ktor.client.HttpClient$4.invokeSuspend(HttpClient.kt:1315)
	at io.ktor.client.HttpClient$4.invoke(HttpClient.kt)
	at io.ktor.client.HttpClient$4.invoke(HttpClient.kt)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.util.pipeline.DebugPipelineContext.proceed(DebugPipelineContext.kt:57)
	at io.ktor.client.plugins.ReceiveError$install$1.invokeSuspend(HttpCallValidator.kt:149)
	at io.ktor.client.plugins.ReceiveError$install$1.invoke(HttpCallValidator.kt)
	at io.ktor.client.plugins.ReceiveError$install$1.invoke(HttpCallValidator.kt)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.util.pipeline.DebugPipelineContext.proceed(DebugPipelineContext.kt:57)
	at io.ktor.util.pipeline.DebugPipelineContext.execute$ktor_utils(DebugPipelineContext.kt:63)
	at io.ktor.util.pipeline.Pipeline.execute(Pipeline.kt:86)
	at io.ktor.client.call.HttpClientCall.bodyNullable(HttpClientCall.kt:87)
	at snd.komf.mediaserver.kavita.KavitaClient.getSeriesMetadata-JayA2N8(KavitaClient.kt:432)
	at snd.komf.mediaserver.kavita.KavitaClient$getSeriesMetadata$1.invokeSuspend(KavitaClient.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:832)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
Caused by: kotlinx.serialization.MissingFieldException: Field 'role' is required for type with serial name 'snd.komf.mediaserver.kavita.model.KavitaAuthor', but it was missing at path: $.writers[0]
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:95)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:168)
	at kotlinx.serialization.encoding.CompositeDecoder$DefaultImpls.decodeSerializableElement$default(Decoding.kt:538)
	at kotlinx.serialization.internal.CollectionLikeSerializer.readElement(CollectionSerializers.kt:80)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.readElement$default(CollectionSerializers.kt:51)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.merge(CollectionSerializers.kt:36)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.deserialize(CollectionSerializers.kt:43)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:168)
	at snd.komf.mediaserver.kavita.model.KavitaSeriesMetadata$$serializer.deserialize(KavitaSeries.kt:51)
	at snd.komf.mediaserver.kavita.model.KavitaSeriesMetadata$$serializer.deserialize(KavitaSeries.kt:51)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:165)
	at io.ktor.serialization.kotlinx.KotlinxSerializationConverter.deserialize(KotlinxSerializationConverter.kt:69)
	... 37 common frames omitted
Caused by: kotlinx.serialization.MissingFieldException: Field 'role' is required for type with serial name 'snd.komf.mediaserver.kavita.model.KavitaAuthor', but it was missing
	at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
	at snd.komf.mediaserver.kavita.model.KavitaAuthor.<init>(KavitaAuthor.kt:26)
	at snd.komf.mediaserver.kavita.model.KavitaAuthor$$serializer.deserialize(KavitaAuthor.kt:26)
	at snd.komf.mediaserver.kavita.model.KavitaAuthor$$serializer.deserialize(KavitaAuthor.kt:26)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	... 54 common frames omitted
	```