### PR TITLE
feat(comicvine): look for volume id in series title

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/ComicVineMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/ComicVineMetadataMapper.kt
@@ -52,6 +52,16 @@ class ComicVineMetadataMapper(
         )
     }
 
+    fun toSeriesSearchResult(volume: ComicVineVolume): SeriesSearchResult {
+        return SeriesSearchResult(
+            url = volume.siteDetailUrl,
+            imageUrl = volume.image?.mediumUrl,
+            title = seriesTitle(volume),
+            provider = CoreProviders.COMIC_VINE,
+            resultId = volume.id.toString()
+        )
+    }
+
     fun toSeriesMetadata(
         volume: ComicVineVolume,
         cover: Image?
@@ -155,6 +165,12 @@ class ComicVineMetadataMapper(
     }
 
     private fun seriesTitle(volume: ComicVineVolumeSearch): String {
+        val publisher = volume.publisher?.name?.let { " ($it)" } ?: ""
+        val startYearString = volume.startYear?.let { " ($it)" } ?: ""
+        return "${volume.name}$startYearString$publisher"
+    }
+
+    private fun seriesTitle(volume: ComicVineVolume): String {
         val publisher = volume.publisher?.name?.let { " ($it)" } ?: ""
         val startYearString = volume.startYear?.let { " ($it)" } ?: ""
         return "${volume.name}$startYearString$publisher"


### PR DESCRIPTION
This is my first time doing anything in Kotlin so I'm sorry if the code is really bad but this PR is mainly a feature request if you are interested in supporting my use case.

I've been working on automating the downloading and metadata tagging of comic books and since I can automatically add the Comicvine ID of volumes to their folder name, I thought it would be nice for Komf to pick that up and match the metadata directly with the Comicvine ID.

As you can see in the code I added, I'm looking at the title of a given series to check for `[CV=<some-id>]` and parse `<some-id>` to then use `client.getVolume` instead of `client.searchVolume`.

I was also thinking this could be a config setting where a user would have to enable `idParsing` or something along those lines and then set the `idParsingRegex` so it would be configurable instead of hardcoded like I did here.

I wrote this code myself just to have a working prototype for my own collection and it's been working very well.