### PR TITLE
Webtoons initial implementation

### DIFF
--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/CommonTypes.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/CommonTypes.kt
@@ -63,6 +63,7 @@ enum class KomfCoreProviders : KomfProviders {
     MANGA_UPDATES,
     MANGADEX,
     NAUTILJON,
+    WEBTOONS,
     YEN_PRESS,
     VIZ,
 }

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
@@ -107,6 +107,7 @@ data class ProvidersConfigDto(
     val comicVine: ProviderConfigDto,
     val hentag: ProviderConfigDto,
     val mangaBaka: ProviderConfigDto,
+    val webtoons: ProviderConfigDto,
 )
 
 sealed interface ProviderConf {

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfigUpdateRequest.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfigUpdateRequest.kt
@@ -106,6 +106,7 @@ data class ProvidersConfigUpdateRequest(
     val comicVine: PatchValue<ProviderConfigUpdateRequest> = PatchValue.Unset,
     val hentag: PatchValue<ProviderConfigUpdateRequest> = PatchValue.Unset,
     val mangaBaka: PatchValue<ProviderConfigUpdateRequest> = PatchValue.Unset,
+    val webtoons: PatchValue<ProviderConfigUpdateRequest> = PatchValue.Unset,
 )
 
 @Serializable

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
@@ -150,6 +150,7 @@ class AppConfigMapper {
             comicVine = toDto(config.comicVine),
             hentag = toDto(config.hentag),
             mangaBaka = toDto(config.mangaBaka),
+            webtoons = toDto(config.webtoons),
         )
     }
 

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigUpdateMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigUpdateMapper.kt
@@ -139,6 +139,8 @@ class AppConfigUpdateMapper {
                 ?.let { providerConfig(config.hentag, it) } ?: config.hentag,
             mangaBaka = patch.mangaBaka.getOrNull()
                 ?.let { providerConfig(config.mangaBaka, it) } ?: config.mangaBaka,
+            webtoons = patch.webtoons.getOrNull()
+                ?.let { providerConfig(config.webtoons, it) } ?: config.webtoons,
         )
     }
 

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/CommonTypesMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/CommonTypesMapper.kt
@@ -96,6 +96,7 @@ fun CoreProviders.fromProvider() = when (this) {
     CoreProviders.MANGA_UPDATES -> KomfCoreProviders.MANGA_UPDATES
     CoreProviders.MANGADEX -> KomfCoreProviders.MANGADEX
     CoreProviders.NAUTILJON -> KomfCoreProviders.NAUTILJON
+    CoreProviders.WEBTOOONS -> KomfCoreProviders.WEBTOONS
     CoreProviders.YEN_PRESS -> KomfCoreProviders.YEN_PRESS
     CoreProviders.VIZ -> KomfCoreProviders.VIZ
 }
@@ -112,6 +113,7 @@ fun KomfProviders.toProvider() = when (this) {
     KomfCoreProviders.MANGA_UPDATES -> CoreProviders.MANGA_UPDATES
     KomfCoreProviders.MANGADEX -> CoreProviders.MANGADEX
     KomfCoreProviders.NAUTILJON -> CoreProviders.NAUTILJON
+    KomfCoreProviders.WEBTOONS -> CoreProviders.WEBTOOONS
     KomfCoreProviders.YEN_PRESS -> CoreProviders.YEN_PRESS
     KomfCoreProviders.VIZ -> CoreProviders.VIZ
     is UnknownKomfProvider -> CoreProviders.valueOf(this.name)

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/CoreProviders.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/CoreProviders.kt
@@ -12,6 +12,7 @@ enum class CoreProviders {
     MANGADEX,
     MANGA_BAKA,
     NAUTILJON,
+    WEBTOOONS,
     YEN_PRESS,
     VIZ,
 }

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/MetadataProvidersConfig.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/MetadataProvidersConfig.kt
@@ -38,6 +38,7 @@ data class ProvidersConfig(
     val comicVine: ProviderConfig = ProviderConfig(),
     val hentag: ProviderConfig = ProviderConfig(),
     val mangaBaka: ProviderConfig = ProviderConfig(),
+    val webtoons: ProviderConfig = ProviderConfig(),
 )
 
 @Serializable

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsClient.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsClient.kt
@@ -1,0 +1,74 @@
+package snd.komf.providers.webtoons
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import snd.komf.model.Image
+import snd.komf.providers.webtoons.model.SearchResult
+import snd.komf.providers.webtoons.model.WebtoonsChapter
+import snd.komf.providers.webtoons.model.WebtoonsSeries
+import snd.komf.providers.webtoons.model.WebtoonsSeriesId
+
+class WebtoonsClient(private val ktor: HttpClient) {
+    private val parser = WebtoonsParser()
+
+    private val baseUrl = "https://www.webtoons.com"
+    private val mobileBaseUrl = "https://m.webtoons.com"
+
+    private val baseHeaders: Headers = Headers.build {
+        append(HttpHeaders.Referrer, "$baseUrl/en")
+    }
+
+    private val mobileHeaders: Headers = Headers.build {
+        append(HttpHeaders.Referrer, mobileBaseUrl)
+    }
+
+    suspend fun searchSeries(name: String): Collection<SearchResult> {
+        val document = ktor.get("$baseUrl/en/search") { parameter("keyword", name); headers { appendAll(baseHeaders) } }
+            .bodyAsText()
+        return parser.parseSearchResults(document)
+    }
+
+    suspend fun getSeries(id: WebtoonsSeriesId): WebtoonsSeries {
+        val document = ktor.get("$baseUrl${id.value}") { headers { appendAll(baseHeaders) } }.bodyAsText()
+        return parser.parseSeries(document)
+    }
+
+    private suspend fun getSeriesMobile(id: WebtoonsSeriesId): String {
+        val document = ktor.get("$mobileBaseUrl${id.value}") { headers { appendAll(mobileHeaders) } }.bodyAsText()
+        return document
+    }
+
+    suspend fun getChapters(id: WebtoonsSeriesId): Collection<WebtoonsChapter> {
+        // The mobile html contains all the chapters in one single list, no paging needed
+        val mobileSeries = getSeriesMobile(id)
+        return parser.parseChapters(mobileSeries)
+    }
+
+    suspend fun getSeriesWithChapters(id: WebtoonsSeriesId): WebtoonsSeries {
+        val series = getSeries(id)
+
+        series.chapters = getChapters(id)
+        return series
+    }
+
+    suspend fun getSeriesThumbnail(series: WebtoonsSeries): Image? {
+        val urlRaw = series.thumbnailUrl ?: return null
+        // Fetch at full quality
+        val builder = URLBuilder(urlRaw)
+        builder.parameters.remove("type")
+        val bytes: ByteArray = ktor.get(builder.build()) { headers { appendAll(baseHeaders) } }.body()
+        return Image(bytes)
+    }
+
+    suspend fun getChapterThumbnail(chapter: WebtoonsChapter): Image {
+        val urlRaw = chapter.thumbnailUrl
+        // Fetch at full quality, though here it doesn't seem to do much
+        val builder = URLBuilder(urlRaw)
+        builder.parameters.remove("type")
+        val bytes: ByteArray = ktor.get(builder.build()) { headers { appendAll(mobileHeaders) } }.body()
+        return Image(bytes)
+    }
+}

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsMetadataMapper.kt
@@ -1,0 +1,107 @@
+package snd.komf.providers.webtoons
+
+import snd.komf.model.Author
+import snd.komf.model.AuthorRole
+import snd.komf.model.BookMetadata
+import snd.komf.model.BookRange
+import snd.komf.model.Image
+import snd.komf.model.ProviderBookId
+import snd.komf.model.ProviderBookMetadata
+import snd.komf.model.ProviderSeriesId
+import snd.komf.model.ProviderSeriesMetadata
+import snd.komf.model.SeriesBook
+import snd.komf.model.SeriesMetadata
+import snd.komf.model.SeriesSearchResult
+import snd.komf.model.SeriesTitle
+import snd.komf.model.TitleType
+import snd.komf.model.WebLink
+import snd.komf.providers.CoreProviders
+import snd.komf.providers.MetadataConfigApplier
+import snd.komf.providers.SeriesMetadataConfig
+import snd.komf.providers.webtoons.model.SearchResult
+import snd.komf.providers.webtoons.model.WebtoonsChapter
+import snd.komf.providers.webtoons.model.WebtoonsSeries
+
+class WebtoonsMetadataMapper(
+    private val metadataConfig: SeriesMetadataConfig,
+    private val authorRoles: Collection<AuthorRole>,
+    private val artistRoles: Collection<AuthorRole>,
+) {
+    fun toSeriesSearchResult(result: SearchResult): SeriesSearchResult {
+        return SeriesSearchResult(
+            url = result.url,
+            imageUrl = result.imageUrl,
+            title = result.title,
+            provider = CoreProviders.WEBTOOONS,
+            resultId = result.id.value
+        )
+    }
+
+    fun toSeriesMetadata(series: WebtoonsSeries, thumbnail: Image? = null): ProviderSeriesMetadata {
+        val authors = listOfNotNull(
+            series.author?.let { Author(it.name, AuthorRole.WRITER) },
+                    series.adaptedBy?.let { Author(it.name, AuthorRole.EDITOR) },
+                    series.artist?.let { Author(it.name, AuthorRole.COLORIST) },
+        )
+
+        val titles = listOfNotNull(SeriesTitle(series.title, TitleType.LOCALIZED, "en"))
+
+        val metadata = SeriesMetadata(
+            // status = status,
+            titles = titles,
+            summary = series.description,
+            genres = series.genres,
+            authors = authors,
+            thumbnail = thumbnail,
+            // totalBookCount = series.numberOfVolumes,
+            // There's a data-title-unsuitable-for-children=bool in certain places
+            // ageRating = series.recommendedAge,
+            // First chapter release date? Not effective for translated works
+            // releaseDate = ReleaseDate(series.startYear, null, null),
+            links = listOf(WebLink("Webtoon", series.url)),
+            score = series.score,
+            // Maybe worth overriding by default
+            // readingDirection = TODO(),
+            language = "en"
+        )
+
+        val providerMetadata = ProviderSeriesMetadata(
+            id = ProviderSeriesId(series.id.value),
+            metadata = metadata,
+            books = series.chapters?.map {
+                SeriesBook(
+                    id = ProviderBookId(it.id.value),
+                    number = BookRange(it.number),
+                    // TODO: Proper edition
+                    edition = null,
+                    // TODO: Proper type
+                    type = null,
+                    name = it.title
+                )
+            } ?: emptyList()
+        )
+        return MetadataConfigApplier.apply(providerMetadata, metadataConfig)
+    }
+
+    fun toBookMetadata(chapter: WebtoonsChapter, seriesId: ProviderSeriesId, thumbnail: Image?): ProviderBookMetadata {
+        return ProviderBookMetadata(
+            id = ProviderBookId(chapter.id.value),
+            seriesId = seriesId,
+            metadata = BookMetadata(
+                title = chapter.title,
+                //summary = TODO(),
+                number = BookRange(chapter.number),
+                // numberSort = TODO(),
+                releaseDate = chapter.releaseDate,
+                // Mirror series data?
+                //authors = TODO(),
+                links = listOf(WebLink("Webtoon", chapter.url)),
+                // chapters = TODO(),
+                //storyArcs = TODO(),
+                //startChapter = TODO(),
+                //endChapter = TODO(),
+                thumbnail = thumbnail
+            )
+        )
+    }
+}

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsMetadataProvider.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsMetadataProvider.kt
@@ -1,0 +1,69 @@
+package snd.komf.providers.webtoons
+
+import snd.komf.model.Image
+import snd.komf.model.MatchQuery
+import snd.komf.model.MediaType
+import snd.komf.model.ProviderBookId
+import snd.komf.model.ProviderBookMetadata
+import snd.komf.model.ProviderSeriesId
+import snd.komf.model.ProviderSeriesMetadata
+import snd.komf.model.SeriesSearchResult
+import snd.komf.providers.CoreProviders
+import snd.komf.providers.MetadataProvider
+import snd.komf.providers.webtoons.model.WebtoonsChapterId
+import snd.komf.providers.webtoons.model.WebtoonsSeriesId
+import snd.komf.util.NameSimilarityMatcher
+
+class WebtoonsMetadataProvider(
+    private val client: WebtoonsClient,
+    private val metadataMapper: WebtoonsMetadataMapper,
+    private val nameMatcher: NameSimilarityMatcher,
+    private val fetchSeriesCovers: Boolean,
+    private val fetchBookCovers: Boolean,
+    mediaType: MediaType,
+) : MetadataProvider {
+    override fun providerName() = CoreProviders.WEBTOOONS
+
+    override suspend fun getSeriesMetadata(seriesId: ProviderSeriesId): ProviderSeriesMetadata {
+        val seriesWithChapters = client.getSeriesWithChapters(WebtoonsSeriesId(seriesId.value))
+        val thumbnail = if (fetchSeriesCovers) client.getSeriesThumbnail(seriesWithChapters) else null
+
+        return metadataMapper.toSeriesMetadata(seriesWithChapters, thumbnail)
+    }
+
+    override suspend fun getSeriesCover(seriesId: ProviderSeriesId): Image? {
+        val series = client.getSeries(WebtoonsSeriesId(seriesId.value))
+        return client.getSeriesThumbnail(series)
+    }
+
+    override suspend fun getBookMetadata(
+        seriesId: ProviderSeriesId, bookId: ProviderBookId
+    ): ProviderBookMetadata {
+        val chapters = client.getChapters(WebtoonsSeriesId(seriesId.value))
+
+        // Assume that if you're searching with a bookId, that book exists
+        // This can probably fail since Webtoons eventually hides the chapter list for web clients
+        // The app seems to contact somewhere else, and is able to get the full list
+        val chapter = chapters.find { it.id == WebtoonsChapterId(bookId.id) }!!
+
+        val thumbnail = if (fetchBookCovers) client.getChapterThumbnail(chapter) else null
+        return metadataMapper.toBookMetadata(chapter, seriesId, thumbnail)
+    }
+
+    override suspend fun searchSeries(seriesName: String, limit: Int): Collection<SeriesSearchResult> {
+        val searchResults = client.searchSeries(seriesName.take(400)).take(limit)
+        return searchResults.map { metadataMapper.toSeriesSearchResult(it) }
+    }
+
+    override suspend fun matchSeriesMetadata(matchQuery: MatchQuery): ProviderSeriesMetadata? {
+        val seriesName = matchQuery.seriesName
+        val searchResults = client.searchSeries(seriesName.take(400))
+        val match = searchResults.firstOrNull { nameMatcher.matches(seriesName, listOfNotNull(it.title)) }
+
+        return match?.let {
+            val series = client.getSeriesWithChapters(it.id)
+            val thumbnail = if (fetchSeriesCovers) client.getSeriesThumbnail(series) else null
+            metadataMapper.toSeriesMetadata(series, thumbnail)
+        }
+    }
+}

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsParser.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/WebtoonsParser.kt
@@ -1,0 +1,169 @@
+package snd.komf.providers.webtoons
+
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
+import com.fleeksoft.ksoup.select.Elements
+import io.ktor.http.*
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format.MonthNames
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.format.char
+import snd.komf.providers.webtoons.model.PersonInfo
+import snd.komf.providers.webtoons.model.SearchResult
+import snd.komf.providers.webtoons.model.WebtoonsChapter
+import snd.komf.providers.webtoons.model.WebtoonsChapterId
+import snd.komf.providers.webtoons.model.WebtoonsSeries
+import snd.komf.providers.webtoons.model.WebtoonsSeriesId
+
+class WebtoonsParser {
+    private val chapterDateFormat = LocalDate.Format {
+        monthName(
+            MonthNames(
+                "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+            )
+        )
+        char(' ')
+        dayOfMonth(Padding.NONE)
+        char(',')
+        char(' ')
+        year()
+    }
+
+    private val searchEntrySelector = "#content > div.card_wrap.search ul:not(#filterLayer) li a"
+
+    fun parseSearchResults(results: String): Collection<SearchResult> {
+        val document = Ksoup.parse(results)
+        val searchEntries = document.select(searchEntrySelector)
+
+        // logger.error { searchEntries }
+
+        return searchEntries.mapNotNull { entry ->
+            val url = entry.attr("href")
+
+            // Technically title_no is the series ID, but if something has to be stored as an ID, the URL path is easier
+            // val id = Url(url).parameters["title_no"] ?: return@mapNotNull null
+            val id = Url(url).encodedPathAndQuery
+
+            val title = entry.select("p.subj").text()
+            val imageUrl = entry.select("img").attr("src")
+            val genre = entry.select("p.genre").text()
+            val author = entry.select("p.author").text()
+            // Contains expressions like "100K" "3M" "653", not mapped to numbers since it's not used
+            val views = entry.select("p.grade_area em.grade_num").text()
+
+            SearchResult(
+                id = WebtoonsSeriesId(id),
+                title = title,
+                url = url,
+                imageUrl = imageUrl,
+                genre = genre,
+                author = author,
+                views = views
+            )
+        }
+    }
+
+    fun parseSeries(series: String): WebtoonsSeries {
+        val document = Ksoup.parse(series)
+
+        val detailElement = document.select("#content > div.cont_box > div.detail_header > div.info")
+        val infoElement = document.select("#_asideDetail")
+        val peopleElement = document.select("#wrap > div._authorInfoLayer div._authorInnerContent")
+
+        val title = document.selectFirst("h1.subj, h3.subj")!!.text()
+        val description = infoElement.select("p.summary").text()
+        val imageUrl = parseDetailsThumbnail(document)
+        val genres = detailElement.select(".genre").map { it.text() }
+
+        val author: PersonInfo?
+        var adaptedBy: PersonInfo? = null
+        val artist: PersonInfo?
+
+        if (peopleElement.isNotEmpty()) {
+            author = getPersonInfo(peopleElement, "Original work by")
+            adaptedBy = getPersonInfo(peopleElement, "Adapted by")
+            artist = getPersonInfo(peopleElement, "Art by")
+        } else {
+            val authorBackup = detailElement.select(".author_area").first()?.ownText()!!
+            val authorName = detailElement.select(".author:nth-of-type(1)").first()?.ownText() ?: authorBackup
+            val artistName = detailElement.select(".author:nth-of-type(2)").first()?.ownText()
+
+            author = PersonInfo(authorName)
+            artist = PersonInfo(artistName ?: authorName)
+        }
+
+        val views = infoElement.select("li span.ico_view + em").text()
+        val subscribers = infoElement.select("li span.ico_subscribe + em").text()
+        val score = infoElement.select("li span.ico_grade5 + em").text().toDouble()
+
+        return WebtoonsSeries(
+            id = WebtoonsSeriesId(idFromUrl(getDocumentUrl(document))),
+            title = title,
+            description = description,
+            url = getDocumentUrl(document),
+            thumbnailUrl = imageUrl,
+            genres = genres,
+            author = author,
+            adaptedBy = adaptedBy,
+            artist = artist,
+            views = views,
+            subscribers = subscribers,
+            score = score,
+            chapters = null
+        )
+    }
+
+    private fun getDocumentUrl(document: Document): String {
+        return document.getElementsByTag("meta").first { it.attr("property") == "og:url" }.attr("content")
+    }
+
+    private fun idFromUrl(urlRaw: String): String {
+        return Url(urlRaw).encodedPathAndQuery
+    }
+
+    private fun parseDetailsThumbnail(document: Document): String? {
+        val picElement = document.select("#content > div.cont_box > div.detail_body")
+        val discoverPic = document.select("#content > div.cont_box > div.detail_header > span.thmb")
+        return picElement.attr("style").substringAfter("url(").substringBeforeLast(")").removeSurrounding("\"")
+            .removeSurrounding("'")
+            .ifBlank { discoverPic.select("img").not("[alt='Representative image']").first()?.attr("src") }
+    }
+
+    private fun getPersonInfo(peopleElement: Elements, text: String): PersonInfo? {
+        val title = peopleElement.select("p.by:contains($text) + h3.title").first()?.text() ?: return null
+        val description =
+            peopleElement.select("p.by:contains($text) + h3.title").first()?.parent()?.select("p.desc")?.first()?.text()
+        return PersonInfo(title, description)
+    }
+
+    fun parseChapters(mobileSeries: String): Collection<WebtoonsChapter> {
+        val document = Ksoup.parse(mobileSeries)
+
+        val chapters = document.select("ul#_episodeList li[id*=episode]")
+
+        return chapters.map {
+            val urlElement = it.select("a")
+            val chapterUrl = urlElement.attr("href")
+
+            val title = it.select("a > div.row > div.info > p.sub_title > span.ellipsis").text()
+            val chapterNumber = it.select("a > div.row > div.num").text().substringAfter("#").toDouble()
+
+            val thumbnailUrl = it.select("a > div.row > div.pic > img._thumbnail").attr("data-image-url")
+
+            val releaseDate = it.select("a > div.row > div.col > div.sub_info > span.date").text()
+                .let { date -> LocalDate.parse(date, chapterDateFormat) }
+
+            val likes = it.select("a > div.row > div.info > div.sub_info >span.likeList").text()
+
+            WebtoonsChapter(
+                id = WebtoonsChapterId(idFromUrl(chapterUrl)),
+                title = title,
+                url = chapterUrl,
+                number = chapterNumber,
+                thumbnailUrl = thumbnailUrl,
+                releaseDate = releaseDate,
+                likes = likes
+            )
+        }
+    }
+}

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/model/SearchResult.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/model/SearchResult.kt
@@ -1,0 +1,11 @@
+package snd.komf.providers.webtoons.model
+
+data class SearchResult(
+    val id: WebtoonsSeriesId,
+    val title: String,
+    val url: String,
+    val imageUrl: String?,
+    val genre: String,
+    val author: String,
+    val views: String,
+)

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/model/WebtoonsSeries.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/webtoons/model/WebtoonsSeries.kt
@@ -1,0 +1,48 @@
+package snd.komf.providers.webtoons.model
+
+import kotlinx.datetime.LocalDate
+
+@JvmInline
+value class WebtoonsSeriesId(val value: String)
+
+@JvmInline
+value class WebtoonsChapterId(val value: String)
+
+data class WebtoonsSeries(
+    val id: WebtoonsSeriesId,
+    val title: String,
+    val description: String?,
+    val url: String,
+    val thumbnailUrl: String?,
+
+    val genres: Collection<String>,
+
+    // These also sometimes have "other works", not parsing it for now
+    val author: PersonInfo?,
+    val adaptedBy: PersonInfo?,
+    val artist: PersonInfo?,
+
+    // Inconsistent formatting use of "." and "," as separators. Also uses shorthands
+    val views: String,
+    val subscribers: String,
+    val score: Double,
+
+    // There's a schedule of when it releases
+    // val schedule: String,
+
+    var chapters: Collection<WebtoonsChapter>?
+)
+
+data class WebtoonsChapter(
+    val id: WebtoonsChapterId,
+    val title: String,
+    val url: String,
+    val number: Double,
+    val thumbnailUrl: String,
+    val releaseDate: LocalDate,
+    val likes: String,
+)
+
+data class PersonInfo(val name: String, val description: String?) {
+    constructor(name: String) : this(name, null)
+}


### PR DESCRIPTION
Adds Webtoons (https://www.webtoons.com) as a metadata provider. Needs some touching up, but I wanted to get revisions/comments in.

Notes and stuffs:
- I've treated each webtoon _chapter_ as a komf _book_ since that's how Kavita and Komga will treat the dowloaded `.cbz`s, and it allows downloading the chapter images to have proper "covers".
- For testing I needed to do a small patch, since Webtoons very commonly separate by "chapter" rather than "volume", to `BookNameParser.kt`. `WEBTOON` could perhaps be its own content category?
```diff
-    fun getBookNumber(name: String) = getBookNumber(name, bookNumberRegexes)
+    fun getBookNumber(name: String) = getBookNumber(name, bookNumberRegexes) ?: getChapters(name)
```
- There's probably some more metadata mapping that could be done that I've missed
  - Most notably, the publishing status, but that's not easily discoverable from what I could tell
- The source is currently hardcoded to use the english page for simplicity, though it can be "generalised" easily enough
- I'd really like to figure out grabbing all the chapters like the mobile client does before merging, because otherwise "finished" series only have a few chapters to go off
- Author and other roles parsing was done as best-effort, though it may get some values mixed up due to the many varying layouts

Based partly on [keiyoushi](https://github.com/keiyoushi/extensions-source)'s Mihon extension.