### PR TITLE
Remove extra fields in KavitaSeries data model to resolve deserialization issue

### DIFF
--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
@@ -112,11 +112,10 @@ class KavitaMediaServerClientAdapter(private val kavitaClient: KavitaClient) : M
         metadata: MediaServerSeriesMetadataUpdate
     ) {
         val localizedName = metadata.alternativeTitles?.find { it.language != null }
-        if (metadata.title != null || localizedName != null) {
+        if (metadata.titleSort != null || localizedName != null) {
             val series = kavitaClient.getSeries(seriesId.toKavitaSeriesId())
             kavitaClient.updateSeries(
                 series.toKavitaTitleUpdate(
-                    metadata.title?.name,
                     metadata.titleSort?.name,
                     localizedName?.name
                 )
@@ -305,7 +304,7 @@ private fun KavitaSeriesMetadata.toMediaServerSeriesMetadata(series: KavitaSerie
         links = webLinks?.split(",")?.map { WebLink(it, it) } ?: emptyList(),
 
         statusLock = publicationStatusLocked,
-        titleLock = series.nameLocked,
+        titleLock = false,
         titleSortLock = series.sortNameLocked,
         summaryLock = summaryLocked,
         readingDirectionLock = false,
@@ -477,13 +476,11 @@ private fun kavitaSeriesResetRequest(seriesId: KavitaSeriesId): KavitaSeriesMeta
     return KavitaSeriesMetadataUpdateRequest(metadata)
 }
 
-private fun KavitaSeries.toKavitaTitleUpdate(newName: String?, newSortName: String?, newLocalizedName: String?) =
+private fun KavitaSeries.toKavitaTitleUpdate(newSortName: String?, newLocalizedName: String?) =
     KavitaSeriesUpdateRequest(
         id = id,
-        name = newName?.trim() ?: name,
         sortName = newSortName?.trim() ?: sortName,
         localizedName = newLocalizedName?.trim() ?: localizedName,
-        nameLocked = nameLocked,
         sortNameLocked = sortNameLocked,
         localizedNameLocked = localizedNameLocked,
 
@@ -492,10 +489,8 @@ private fun KavitaSeries.toKavitaTitleUpdate(newName: String?, newSortName: Stri
 
 private fun KavitaSeries.toKavitaCoverResetRequest() = KavitaSeriesUpdateRequest(
     id = id,
-    name = name,
     localizedName = localizedName,
     sortName = sortName,
-    nameLocked = false,
     sortNameLocked = false,
     localizedNameLocked = false,
 

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/model/KavitaSeries.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/model/KavitaSeries.kt
@@ -27,14 +27,12 @@ class KavitaSeries(
     val originalName: String,
     val localizedName: String? = null,
     val sortName: String,
-    val summary: String? = null,
     val pages: Int,
     val format: Int,
     val created: LocalDateTime,
     val folderPath: String,
     val coverImageLocked: Boolean,
     val localizedNameLocked: Boolean,
-    val nameLocked: Boolean,
     val sortNameLocked: Boolean,
 )
 

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/model/request/KavitaSeriesUpdateRequest.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/model/request/KavitaSeriesUpdateRequest.kt
@@ -6,11 +6,9 @@ import snd.komf.mediaserver.kavita.model.KavitaSeriesId
 @Serializable
 data class KavitaSeriesUpdateRequest(
     val id: KavitaSeriesId,
-    val name: String,
     val localizedName: String? = null,
     val sortName: String,
     val coverImageLocked: Boolean,
-    val nameLocked: Boolean,
     val sortNameLocked: Boolean,
     val localizedNameLocked: Boolean
 )


### PR DESCRIPTION
Fix #222 by removing 'nameLocked' field from KavitaSeries, which doesn't exist in Kavita API.

Also removed the following fields that don't exist in Kavita API:
- 'summary' from KavitaSeries.
- 'name' and 'nameLocked' from KavitaSeriesUpdateRequest.