### PR TITLE
add ComicVine limit search configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ database:
 metadataProviders:
   malClientId: "" # required for mal provider. See https://myanimelist.net/forum/?topicid=1973077 env:KOMF_METADATA_PROVIDERS_MAL_CLIENT_ID
   comicVineApiKey: # required for comicVine provider https://comicvine.gamespot.com/api/ env:KOMF_METADATA_PROVIDERS_COMIC_VINE_API_KEY
+  comicVineSearchLimit: # define ComicVine search result Limit, default is 10 
   bangumiToken: # bangumi provider require a token to show nsfw items https://next.bgm.tv/demo/access-token  env:KOMF_METADATA_PROVIDERS_BANGUMI_TOKEN
   defaultProviders:
     mangaUpdates:

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
@@ -89,6 +89,7 @@ data class EventListenerConfigDto(
 data class MetadataProvidersConfigDto(
     val malClientId: String?,
     val comicVineClientId: String?,
+    val comicVineSearchLimit: Int?,
     val nameMatchingMode: KomfNameMatchingMode,
     val defaultProviders: ProvidersConfigDto,
     val libraryProviders: Map<String, ProvidersConfigDto>,

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
@@ -138,6 +138,7 @@ class AppConfigMapper {
         return MetadataProvidersConfigDto(
             malClientId = malClientId,
             comicVineClientId = comicVineClientId,
+            comicVineSearchLimit = config.comicVineSearchLimit,
             nameMatchingMode = config.nameMatchingMode.fromNameMatchingMode(),
             defaultProviders = toDto(config.defaultProviders),
             libraryProviders = config.libraryProviders

--- a/komf-app/src/main/kotlin/snd/komf/app/config/ConfigLoader.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/config/ConfigLoader.kt
@@ -73,6 +73,8 @@ class ConfigLoader(private val yaml: Yaml) {
             ?: metadataProvidersConfig.malClientId
         val comicVineApiKey = System.getenv("KOMF_METADATA_PROVIDERS_COMIC_VINE_API_KEY")?.ifBlank { null }
             ?: metadataProvidersConfig.comicVineApiKey
+        val comicVineSearchLimit = System.getenv("KOMF_METADATA_PROVIDERS_COMIC_VINE_SEARCH_LIMIT")?.ifBlank { null }
+            ?: metadataProvidersConfig.comicVineSearchLimit
         val bangumiToken = System.getenv("KOMF_METADATA_PROVIDERS_BANGUMI_TOKEN")?.ifBlank { null }
             ?: metadataProvidersConfig.bangumiToken
 

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/MetadataProvidersConfig.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/MetadataProvidersConfig.kt
@@ -17,6 +17,7 @@ import snd.komf.util.NameSimilarityMatcher.NameMatchingMode
 data class MetadataProvidersConfig(
     val malClientId: String? = null,
     val comicVineApiKey: String? = null,
+    val comicVineSearchLimit: Int? = null,
     val bangumiToken: String? = null,
     val nameMatchingMode: NameMatchingMode = NameMatchingMode.CLOSEST_MATCH,
     val defaultProviders: ProvidersConfig = ProvidersConfig(),

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/ProvidersModule.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/ProvidersModule.kt
@@ -105,6 +105,7 @@ class ProvidersModule(
             defaultNameMatcher = defaultNameMatcher,
             malClientId = config.malClientId,
             comicVineClientId = config.comicVineApiKey,
+            comicVineSearchLimit = config.comicVineSearchLimit,
             bangumiToken = config.bangumiToken,
         )
         val libraryProviders = config.libraryProviders
@@ -114,6 +115,7 @@ class ProvidersModule(
                     defaultNameMatcher = defaultNameMatcher,
                     malClientId = config.malClientId,
                     comicVineClientId = config.comicVineApiKey,
+                    comicVineSearchLimit = config.comicVineSearchLimit,
                     bangumiToken = config.bangumiToken,
                 )
             }
@@ -328,6 +330,7 @@ class ProvidersModule(
         defaultNameMatcher: NameSimilarityMatcher,
         malClientId: String?,
         comicVineClientId: String?,
+        comicVineSearchLimit: Int?,
         bangumiToken: String?,
     ): MetadataProvidersContainer {
         return MetadataProvidersContainer(
@@ -394,6 +397,7 @@ class ProvidersModule(
             comicVine = createComicVineMetadataProvider(
                 config = config.comicVine,
                 apiKey = comicVineClientId,
+                comicVineSearchLimit = comicVineSearchLimit,
                 rateLimiter = comicVineRateLimiter,
                 defaultNameMatcher = defaultNameMatcher,
             ),
@@ -694,6 +698,7 @@ class ProvidersModule(
     private fun createComicVineMetadataProvider(
         config: ProviderConfig,
         apiKey: String?,
+        comicVineSearchLimit: Int? = 10,
         rateLimiter: ComicVineRateLimiter,
         defaultNameMatcher: NameSimilarityMatcher,
     ): ComicVineMetadataProvider? {
@@ -708,6 +713,7 @@ class ProvidersModule(
                 }
             },
             apiKey = apiKey,
+            comicVineSearchLimit = comicVineSearchLimit,
             rateLimiter = rateLimiter
         )
         val metadataMapper = ComicVineMetadataMapper(

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/ComicVineClient.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/ComicVineClient.kt
@@ -20,6 +20,7 @@ private const val baseUrl = "https://comicvine.gamespot.com/api"
 class ComicVineClient(
     private val ktor: HttpClient,
     private val apiKey: String,
+    private val comicVineSearchLimit: Int? = 10,
     private val rateLimiter: ComicVineRateLimiter,
 ) {
 
@@ -29,6 +30,7 @@ class ComicVineClient(
             parameter("query", name)
             parameter("format", "json")
             parameter("resources", "volume")
+            parameter("limit", comicVineSearchLimit)
             parameter("api_key", apiKey)
         }.body()
     }


### PR DESCRIPTION
this add the possibility to configure the ComicVine provider with a search limit to allow more than 10 results to be retrieved for common series name.
The parameter is named comicVineSearchLimit and has to be placed in the "metadataProviders" configuration part