### PR TITLE
fix mangaupdates fields

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/MangaUpdatesClient.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/MangaUpdatesClient.kt
@@ -31,8 +31,8 @@ class MangaUpdatesClient(
                 MangaUpdatesSearchRequest(
                     search = name,
                     page = page,
-                    perPage = perPage,
-                    types = types,
+                    perpage = perPage,
+                    type = types,
                 )
             )
         }.body<SearchResultPage>()
@@ -105,8 +105,8 @@ class MangaUpdatesClient(
     private data class MangaUpdatesSearchRequest(
         val search: String,
         val page: Int,
-        val perPage: Int,
-        val types: Collection<SeriesType>
+        val perpage: Int,
+        val type: Collection<SeriesType>
     )
 }
 

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/model/MangaUpdatesSearchRequest.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/model/MangaUpdatesSearchRequest.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.Serializable
 data class MangaUpdatesSearchRequest(
     val search: String,
     val page: Int,
-    val perPage: Int,
+    val perpage: Int,
     val type: List<SeriesType>
 )

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/model/SeriesType.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/model/SeriesType.kt
@@ -1,5 +1,14 @@
 package snd.komf.providers.mangaupdates.model
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(SeriesTypeSerializer::class)
 enum class SeriesType(val value: String) {
     ARTBOOK("Artbook"),
     DOUJINSHI("Doujinshi"),
@@ -16,4 +25,18 @@ enum class SeriesType(val value: String) {
     FRENCH("French"),
     SPANISH("Spanish"),
     NOVEL("Novel")
+}
+
+@Serializer(forClass = SeriesType::class)
+object SeriesTypeSerializer : KSerializer<SeriesType> {
+    override val descriptor = PrimitiveSerialDescriptor("SeriesType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: SeriesType) {
+        encoder.encodeString(value.value)
+    }
+
+    override fun deserialize(decoder: Decoder): SeriesType {
+        val value = decoder.decodeString()
+        return SeriesType.values().first { it.value == value }
+    }
 }


### PR DESCRIPTION
With the current field names and casing the type filtering doesn't work, also the perPage parameter is ignored. Renamed the relevant fields and serialized the types in SeriesType to have the correct casing, filtering then works as expected.
`types` => `type`
`perPage` => `perpage`

Before
```json
{"search":"Manga Title","page":1,"perPage":5,"types":["MANGA","MANHWA","MANHUA","ARTBOOK","DOUJINSHI","FILIPINO","INDONESIAN","THAI","VIETNAMESE","MALAYSIAN","OEL","NORDIC","FRENCH","SPANISH"]}
{"search":"Novel Title","page":1,"perPage":5,"types":["NOVEL"]}
```
After
``` json
{"search":"Manga Title","page":1,"perpage":5,"type":["Manga","Manhwa","Manhua","Artbook","Doujinshi","Filipino","Indonesian","Thai","Vietnamese","Malaysian","OEL","Nordic","French","Spanish"]}
{"search":"Novel Title","page":1,"perpage":5,"type":["Novel"]}
```