### PR TITLE
Update MangaBakaSeries.kt

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt
@@ -173,9 +173,16 @@ data class MangaBakaSources(
     val kitsu: MangaBakaKitsuSource? = null,
     @SerialName("manga_updates")
     val mangaUpdates: MangaBakaMangaUpdatesSource? = null,
+    @SerialName("mangadex")
     val mangadex: MangaBakaMangaDexSource? = null,
     @SerialName("my_anime_list")
     val myAnimeList: MangaBakaMyAnimeListSource? = null,
+)
+
+@Serializable
+data class MangaBakaMangaDexSource(
+    val id: Int? = null,
+    val rating: Double? = null,
 )
 
 @Serializable

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt
@@ -173,16 +173,8 @@ data class MangaBakaSources(
     val kitsu: MangaBakaKitsuSource? = null,
     @SerialName("manga_updates")
     val mangaUpdates: MangaBakaMangaUpdatesSource? = null,
-    @SerialName("mangadex")
-    val mangadex: MangaBakaMangaDexSource? = null,
     @SerialName("my_anime_list")
     val myAnimeList: MangaBakaMyAnimeListSource? = null,
-)
-
-@Serializable
-data class MangaBakaMangaDexSource(
-    val id: Int? = null,
-    val rating: Double? = null,
 )
 
 @Serializable


### PR DESCRIPTION
fix missing reference causing build failure

With this added building works as expected

I want to note that I am not sure if @SerialName("mangadex") is needed but I was trying to follow the other examples in the lists

PR #263 appears to have missed a reference
```
e: file:///workspace/soultaco83/komf/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt:176:19 Unresolved reference 'MangaBakaMangaDexSource'.
e: file:///workspace/soultaco83/komf/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt:176:19 Serializer has not been found for type 'ERROR CLASS: Symbol not found for MangaBakaMangaDexSource?'. To use context serializer as fallback, explicitly annotate type or property with @Contextual
```