### PR TITLE
Correctly parse volume and chapter when at start of filename

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
@@ -4,14 +4,14 @@ import snd.komf.model.BookRange
 
 object BookNameParser {
     private val volumeRegexes = listOf(
-        "(?i),?\\s\\(?volume\\s(?<volumeStart>[0-9]+)(,?\\s?[0-9]+,)+(?<volumeEnd>\\s?[0-9]+)\\)?".toRegex(),
-        "(?i),?\\s\\(?([vtT]|vols\\.\\s|vol\\.\\s|volume\\s)(?<volumeStart>[0-9]+([.x#][0-9]+)?)(?<volumeEnd>-[0-9]+([.x#][0-9]+)?)?\\)?".toRegex(),
+        "(?i)(?:^|,?\\s)\\(?volume\\s(?<volumeStart>[0-9]+)(,?\\s?[0-9]+,)+(?<volumeEnd>\\s?[0-9]+)\\)?".toRegex(),
+        "(?i)(?:^|,?\\s)\\(?([vtT]|vols\\.\\s|vol\\.\\s|volume\\s)(?<volumeStart>[0-9]+([.x#][0-9]+)?)(?<volumeEnd>-[0-9]+([.x#][0-9]+)?)?\\)?".toRegex(),
         ".*第(?<volumeStart>\\d+)-?(?<volumeEnd>\\d+)?.*巻".toRegex(),
         ".*年(?:[0-9]+月)?(?:[0-9]+日)?(?<volumeStart>\\d+)-?(?<volumeEnd>\\d+)?号".toRegex(),
     )
 
     private val chapterRegexes = listOf(
-        "(?i)(\\sc|\\s?ch\\.\\s|\\s?chapter\\s|\\s?ep\\.\\s)(?<start>[0-9]+([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?".toRegex(),
+        "(?i)(?:^|\\s?)(c|ch\\.\\s|chapter\\s|ep\\.\\s)(?<start>[0-9]+([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?".toRegex(),
         ".*第(?<start>\\d+(\\.\\d+)?)-?(?<end>\\d+(\\.\\d+)?)?.*話".toRegex(),
     )
     private val bookNumberRegexes = listOf(


### PR DESCRIPTION
### Summary

This adjusts `volumeRegexes` and `chapterRegexes` to find matches that start at the beginning of a filename. These changes allow for proper reordering of volumes before chapters (and, where possible, locking in chapters) in cases where a Mihon derivative has stripped the series title from the filename.

### Problem

Suwayomi-Server (one of many Mihon derivatives) automatically strips the series title from the filename when downloading, but ONLY IF it's an exact match. (I believe it matches using the `<Series>` in `ComicInfo.xml`.)

Komf's current regexes do not recognize volumes in the modified filenames, which prevents them from being reordered before chapters in Komga.

| Series title in source | Original filename | Gets downloaded as |
|--------|--------|--------|
| Urasakai Picnic | Otherside Picnic v01 (2021) (Digital).cbz | _(same)_ |
| Blame! | BLAME! Master Edition v01 (2016) (Digital).cbz | _(same)_ |
| Gachi Akuta | Gachiakuta v01 (2024) (Digital).cbz | _(same)_ |
| Dandadan | Dandadan v01 (2022) (Digital).cbz  | v01 (2022) (Digital).cbz |
| Jujutsu Kaisen Modulo | Jujutsu Kaisen Modulo 001 (2025) (Digital).cbz  | 001 (2025) (Digital).cbz |

This behavior apparently comes from Mihon (or earlier), and the likelihood of the upstream project changing it appears to be very low. Thus, the attempt to accommodate it in Komf.

### Changes

**Volume:** Replaces `,?\s` with `(?:^|,?\s)` (matches line start OR optional comma and required whitespace)

**Chapter:** Factors out whitespace from `(\sc|\s?ch\.\s|\s?chapter\s|\s?ep\.\s)` and replaces with `(?:^|\s?)(c|ch\.\s|chapter\s|ep\.\s)` (matches line start OR optional whitespace; makes leading whitespace optional for all chapter conventions).

### Impact

- Volumes are always recognized when starting a filename.
- Chapters are recognized when starting a filename.
- Small false positive risk for titles that include a number directly after `c`. (I could not find any such titles.)

### Testing

- Compiled Komf locally with modified regexes.
- Ran on my Komga collection with no ill effects, and volumes parsed properly.

### Other notes

Despite the examples I gave, I did not change anything that would allow Komf to recognize manga chapters in the format `###`—whether after a title or not—as the risk of false positives is too high. However, Komga parses leading numbers itself just fine, so IMO only volume handling is essential.

If the changes to chapter regexes are controversial, I'm happy to back off of them, but would strongly prefer allowing the modified volume regex regardless. :)