### PR TITLE
Add Option to Fallback to Series Cover when syncing Book Covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ komga:
       mergeGenres: false # if true and aggregate is enabled will merge genres from all providers
       bookCovers: false # update book thumbnails
       seriesCovers: false # update series thumbnails
+      fallbackUseSeriesCoverForBook: false # If updating series cover and book cover, and no book cover exists, use the series cover for the book cover.
       overrideExistingCovers: true # if false will upload but not select new cover if another cover already exists
       overrideComicInfo: false # Replace existing ComicInfo file. If false, only append additional data
       postProcessing:
@@ -144,6 +145,7 @@ kavita:
       mergeGenres: false # if true and aggregate is enabled will merge genres from all providers
       bookCovers: false #update book thumbnails
       seriesCovers: false #update series thumbnails
+      fallbackUseSeriesCoverForBook: false # If updating series cover and book cover, and no book cover exists, use the series cover for the book cover.
       overrideExistingCovers: true # if false will upload but not select new cover if another cover already exists
       lockCovers: true # lock cover images so that kavita does not change them
       postProcessing:
@@ -259,6 +261,7 @@ komga_or_kavita:
         aggregate: false
         bookCovers: false
         seriesCovers: false
+        fallbackUseSeriesCoverForBook: false
         postProcessing:
           seriesTitle: false
           titleType: LOCALIZED

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfig.kt
@@ -47,6 +47,7 @@ data class MetadataProcessingConfigDto(
     val mergeGenres: Boolean,
     val bookCovers: Boolean,
     val seriesCovers: Boolean,
+    val fallbackUseSeriesCoverForBook: Boolean,
     val overrideExistingCovers: Boolean,
     val lockCovers: Boolean,
 

--- a/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfigUpdateRequest.kt
+++ b/komf-api-models/src/commonMain/kotlin/snd/komf/api/config/KomfConfigUpdateRequest.kt
@@ -50,6 +50,7 @@ data class MetadataProcessingConfigUpdateRequest(
 
     val bookCovers: PatchValue<Boolean> = PatchValue.Unset,
     val seriesCovers: PatchValue<Boolean> = PatchValue.Unset,
+    val fallbackUseSeriesCoverForBook: PatchValue<Boolean> = PatchValue.Unset,
     val overrideExistingCovers: PatchValue<Boolean> = PatchValue.Unset,
     val lockCovers: PatchValue<Boolean> = PatchValue.Unset,
     val updateModes: PatchValue<Collection<KomfUpdateMode>> = PatchValue.Unset,

--- a/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/DeprecatedConfigUpdateMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/DeprecatedConfigUpdateMapper.kt
@@ -116,6 +116,7 @@ class DeprecatedConfigUpdateMapper {
             mergeGenres = config.mergeGenres,
             bookCovers = config.bookCovers,
             seriesCovers = config.seriesCovers,
+            fallbackUseSeriesCoverForBook = config.fallbackUseSeriesCoverForBook,
             overrideExistingCovers = config.overrideExistingCovers,
             lockCovers = config.lockCovers,
             updateModes = config.updateModes,
@@ -544,6 +545,7 @@ class DeprecatedConfigUpdateMapper {
             mergeGenres = patch.mergeGenres ?: config.mergeGenres,
             bookCovers = patch.bookCovers ?: config.bookCovers,
             seriesCovers = patch.seriesCovers ?: config.seriesCovers,
+            fallbackUseSeriesCoverForBook = patch.fallbackUseSeriesCoverForBook ?: config.fallbackUseSeriesCoverForBook,
             overrideExistingCovers = patch.overrideExistingCovers ?: config.overrideExistingCovers,
             updateModes = patch.updateModes ?: config.updateModes,
             postProcessing = patch.postProcessing

--- a/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigDto.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigDto.kt
@@ -51,6 +51,7 @@ data class MetadataProcessingConfigDto(
     val mergeGenres: Boolean,
     val bookCovers: Boolean,
     val seriesCovers: Boolean,
+    val fallbackUseSeriesCoverForBook: Boolean,
     val overrideExistingCovers: Boolean,
     var lockCovers: Boolean,
     val updateModes: List<UpdateMode>,

--- a/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigUpdateDto.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/deprecated/dto/AppConfigUpdateDto.kt
@@ -59,6 +59,7 @@ data class MetadataProcessingConfigUpdateDto(
     val mergeTags: Boolean? = null,
     val mergeGenres: Boolean? = null,
     val seriesCovers: Boolean? = null,
+    val fallbackUseSeriesCoverForBook: Boolean? = null,
     val overrideExistingCovers: Boolean? = null,
     var lockCovers: Boolean? = null,
     val updateModes: List<UpdateMode>? = null,

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigMapper.kt
@@ -98,6 +98,7 @@ class AppConfigMapper {
             mergeGenres = config.mergeGenres,
             bookCovers = config.bookCovers,
             seriesCovers = config.seriesCovers,
+            fallbackUseSeriesCoverForBook = config.fallbackUseSeriesCoverForBook,
             overrideExistingCovers = config.overrideExistingCovers,
             lockCovers = config.lockCovers,
             updateModes = config.updateModes.map { it.fromUpdateMode() },

--- a/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigUpdateMapper.kt
+++ b/komf-app/src/main/kotlin/snd/komf/app/api/mappers/AppConfigUpdateMapper.kt
@@ -383,6 +383,7 @@ class AppConfigUpdateMapper {
             mergeGenres = patch.mergeGenres.getOrNull() ?: config.mergeGenres,
             bookCovers = patch.bookCovers.getOrNull() ?: config.bookCovers,
             seriesCovers = patch.seriesCovers.getOrNull() ?: config.seriesCovers,
+            fallbackUseSeriesCoverForBook = patch.fallbackUseSeriesCoverForBook.getOrNull() ?: config.fallbackUseSeriesCoverForBook,
             overrideExistingCovers = patch.overrideExistingCovers.getOrNull() ?: config.overrideExistingCovers,
             lockCovers = patch.lockCovers.getOrNull() ?: config.lockCovers,
             updateModes = patch.updateModes.getOrNull()?.map { it.toUpdateMode() } ?: config.updateModes,

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/MediaServerModule.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/MediaServerModule.kt
@@ -352,6 +352,7 @@ class MediaServerModule(
             updateModes = config.updateModes.toSet(),
             uploadBookCovers = config.bookCovers,
             uploadSeriesCovers = config.seriesCovers,
+            fallbackUseSeriesCoverForBook = config.fallbackUseSeriesCoverForBook,
             overrideExistingCovers = config.overrideExistingCovers,
             lockCovers = config.lockCovers,
         )

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/config/MediaServerConfig.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/config/MediaServerConfig.kt
@@ -49,6 +49,7 @@ data class MetadataProcessingConfig(
 
     val bookCovers: Boolean = false,
     val seriesCovers: Boolean = false,
+    val fallbackUseSeriesCoverForBook: Boolean = false,
     val overrideExistingCovers: Boolean = true,
     var lockCovers: Boolean = true,
     val updateModes: List<UpdateMode> = listOf(API),

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataUpdater.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataUpdater.kt
@@ -34,6 +34,7 @@ class MetadataUpdater(
     private val overrideExistingCovers: Boolean,
     private val uploadBookCovers: Boolean,
     private val uploadSeriesCovers: Boolean,
+    private val fallbackUseSeriesCoverForBook: Boolean,
     private val lockCovers: Boolean,
 ) {
     private val requireMetadataRefresh = setOf(UpdateMode.COMIC_INFO)
@@ -136,7 +137,9 @@ class MetadataUpdater(
             }
         }
 
-        val newThumbnail = if (uploadBookCovers) metadata?.thumbnail else null
+        val newThumbnail = if (uploadBookCovers) {
+            metadata?.thumbnail ?: if (fallbackUseSeriesCoverForBook && uploadSeriesCovers) seriesMeta.thumbnail else null
+        } else null
         val thumbnailId = replaceBookThumbnail(book.id, newThumbnail)
 
         if (thumbnailId == null) {


### PR DESCRIPTION
**Summary**

For users who wish to have their book covers match their series covers when no other cover option exists. Primary use case is Komga users who wish to see book/chapter covers on their home screens (i.e., Keep Reading, On Deck, Recently Added) that is more visually appealing than the first page of that book/chapter. Many users lack local artwork to leverage Komga's native cover capability for each book and sources used by Komf may have have limited book covers for Webtoon, Manhwa, and so on. This option augments that native series/book update capability in Komf to use the series cover in the event a book cover was not found. 

**Behavior**
- Flag name: fallbackUseSeriesCoverForBook (default: false)
- Only when processing configuration is **true** for the following options: bookCovers, seriesCovers, and fallbackUseSeriesCoverForBook
- Komf will apply the Series Cover to the Book Cover Metadata, only when no Book Cover Metadata was returned by the provider.

**Testing**
- Feature was tested across several providers (single and aggregate) for three library types (Manga, Manhwa, and Webtoon)
- Feature was tested against a large Komga library (~140 series & +17k books)
- Was not tested in Kavita
- Could not directly test new web browser extensions (option unavailable).

I welcome any feedback.

Note: This update leveraged Chatgpt Codex to assist in the development and documentation. I'm unaware if this conflicts with the repo's development philosophy.