### PR TITLE
fix(ComicVine): enable per-issue metadata for dash-delimited comic filenames

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
@@ -18,6 +18,7 @@ object BookNameParser {
         "(?i)(?:\\s|#|no\\.)(?<start>[0-9]+[AB]?([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?(?:\\s\\(.*\\)\\s*)*$".toRegex(),
         "Issue (?<start>[0-9]+[AB]?([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?".toRegex(),
         "Volume (?<start>[0-9]+[AB]?([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?".toRegex(),
+        "\\s-\\s(?<start>[0-9]+[AB]?([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?\\s-\\s".toRegex(),
     )
     private val extraDataRegex = "\\[(?<extra>.*?)]".toRegex()
 

--- a/komf-core/src/commonTest/kotlin/snd/komf/util/BookNameParserTest.kt
+++ b/komf-core/src/commonTest/kotlin/snd/komf/util/BookNameParserTest.kt
@@ -1,0 +1,77 @@
+package snd.komf.util
+
+import snd.komf.model.BookRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BookNameParserTest {
+
+    @Test
+    fun `getBookNumber parses number at end of string`() {
+        assertEquals(BookRange(123.0), BookNameParser.getBookNumber("Batman 123"))
+    }
+
+    @Test
+    fun `getBookNumber parses hash-prefixed number`() {
+        assertEquals(BookRange(5.0), BookNameParser.getBookNumber("Spider-Man #5"))
+    }
+
+    @Test
+    fun `getBookNumber parses Issue prefix`() {
+        assertEquals(BookRange(42.0), BookNameParser.getBookNumber("Issue 42"))
+    }
+
+    @Test
+    fun `getBookNumber parses Volume prefix`() {
+        assertEquals(BookRange(3.0), BookNameParser.getBookNumber("Volume 3"))
+    }
+
+    @Test
+    fun `getBookNumber parses number with parenthetical suffix`() {
+        assertEquals(BookRange(10.0), BookNameParser.getBookNumber("Series 10 (2020)"))
+    }
+
+    @Test
+    fun `getBookNumber parses dash-delimited number`() {
+        assertEquals(
+            BookRange(195.0),
+            BookNameParser.getBookNumber("Suske En Wiske HQ - 195 - De Hippe Heksen")
+        )
+    }
+
+    @Test
+    fun `getBookNumber parses dash-delimited leading zeros`() {
+        assertEquals(
+            BookRange(1.0),
+            BookNameParser.getBookNumber("The Walking Dead - 001 - Days Gone Bye")
+        )
+    }
+
+    @Test
+    fun `getBookNumber parses dash-delimited decimal number`() {
+        assertEquals(
+            BookRange(12.5),
+            BookNameParser.getBookNumber("Series - 12.5 - Special Edition")
+        )
+    }
+
+    @Test
+    fun `getBookNumber parses dash-delimited range`() {
+        assertEquals(
+            BookRange(1.0, 5.0),
+            BookNameParser.getBookNumber("Series - 1-5 - Omnibus")
+        )
+    }
+
+    @Test
+    fun `getBookNumber prefers existing regex over dash-delimited`() {
+        // "Issue 5" should match the Issue regex, not the dash pattern
+        assertEquals(BookRange(5.0), BookNameParser.getBookNumber("Series - 2099 - Issue 5"))
+    }
+
+    @Test
+    fun `getBookNumber returns null for unrecognized format`() {
+        assertNull(BookNameParser.getBookNumber("No Number Here"))
+    }
+}

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataService.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataService.kt
@@ -296,6 +296,7 @@ class MetadataService(
             else mapOf(books.first() to null)
         }
 
+        logger.debug { "Matching ${books.size} books against ${providerBooks.size} provider books" }
         return books.associateWith { book ->
             val bookExtraData = BookNameParser.getExtraData(book.name).map { it.lowercase() }
             editionBooks.keys.firstOrNull { bookExtraData.contains(it) }
@@ -303,6 +304,7 @@ class MetadataService(
             val bookNumber = getBookNumber(book.name)
             val providerBook = editionBooks[edition]
                 ?.firstOrNull { it.number != null && it.number == bookNumber }
+            logger.debug { "Book '${book.name}': parsed number=$bookNumber, matched=${providerBook != null}" }
             book to providerBook
         }.toMap()
     }


### PR DESCRIPTION
## Problem

When identifying a ComicVine series, individual book titles, covers, and descriptions are not updated in Komga. The PATCH body is only 43 bytes (just `numberSort`), despite ComicVine having full per-issue data.

**Root cause**: `BookNameParser.getBookNumber()` cannot parse issue numbers from the common European comic filename pattern `Series Name - NUMBER - Issue Title` (e.g. `Suske En Wiske - 195 - De Hippe Heksen`). The existing regexes only match:
- Numbers at the **end** of the string
- `Issue NUMBER` / `Volume NUMBER` prefixes

When parsing fails, `associateBookMetadata()` returns `null` for every book, so `provider.getBookMetadata()` (which calls `/api/issue/{id}/`) is **never called** — even though that code path is fully implemented and working.

## Fix

Add a last-priority fallback regex to `bookNumberRegexes` that matches ` - NUMBER - ` patterns:

```kotlin
"\\s-\\s(?<start>[0-9]+[AB]?([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?\\s-\\s".toRegex()
```

This matches filenames like:
- `Suske En Wiske - 195 - De Hippe Heksen` → 195
- `The Walking Dead - 001 - Days Gone Bye` → 1
- `Series - 12.5 - Special` → 12.5

The new regex is appended **last** so it only fires when all existing patterns fail — no impact on `#123`, `Issue N`, `Volume N`, or end-of-string number patterns.

Also adds debug logging to `associateBookMetadata()` to make book matching failures visible.

## Notes

- This fix only takes effect when the default processing library type is set to **COMIC** (not MANGA). With MANGA, `MetadataService.getBookNumber()` calls `getVolumes()` instead of `getBookNumber()`, so the new regex is never reached.
- Tested on a 175-book series: all books matched, PATCH bodies grew from 43 bytes to ~260 bytes, and per-issue covers were uploaded to Komga.

Closes #293