### PR TITLE
MangaBaka: handle 404 cover image fetch gracefully

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -E \"\\\\.kt$\")",
+      "Bash(xargs grep *)",
+      "Bash(gh pr create --repo Snd-R/komf --head gregoryn22:claude/naughty-wright-33903c --base master --title 'MangaBaka: handle 404 cover image fetch gracefully' --body ' *)",
+      "Bash(gh pr *)"
+    ]
+  }
+}

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaMetadataProvider.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaMetadataProvider.kt
@@ -1,9 +1,12 @@
 package snd.komf.providers.mangabaka
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.reactivecircus.cache4k.Cache
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import snd.komf.model.Image
 import snd.komf.model.MatchQuery
@@ -17,6 +20,8 @@ import snd.komf.providers.CoreProviders
 import snd.komf.providers.MetadataProvider
 import snd.komf.util.NameSimilarityMatcher
 import kotlin.time.Duration.Companion.minutes
+
+private val logger = KotlinLogging.logger {}
 
 class MangaBakaMetadataProvider(
     private val dataSource: MangaBakaDataSource,
@@ -103,12 +108,19 @@ class MangaBakaMetadataProvider(
 
     private suspend fun fetchCover(series: MangaBakaSeries): Image? {
         if (coverFetchClient == null || series.cover.x350?.x1 == null) return null
-
-        val response = coverFetchClient.get(series.cover.x350.x1)
-        return Image(
-            response.body(),
-            response.contentType()?.let { "${it.contentType}/${it.contentSubtype}" }
-        )
+        val url = series.cover.x350.x1
+        return try {
+            val response = coverFetchClient.get(url)
+            Image(
+                response.body(),
+                response.contentType()?.let { "${it.contentType}/${it.contentSubtype}" }
+            )
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.NotFound) {
+                logger.warn { "Cover image not found for series '${series.title}' (${e.response.status}), continuing without cover" }
+                null
+            } else throw e
+        }
     }
 
     private fun ProviderSeriesId.toMangaBakaId() = MangaBakaSeriesId(this.value.toInt())


### PR DESCRIPTION
## Problem

When MangaBaka's CDN returns a 404 for a cover image URL that is present in the API response, `fetchCover()` throws an unhandled `ClientRequestException`. This exception propagates up through `getSeriesMetadata()` / `matchSeriesMetadata()`, causing the **entire identify/match operation to fail** even though the series metadata was fetched successfully.

This is a real-world reliability issue: MangaBaka sometimes includes cover URLs in API responses that no longer resolve (returning 404 + a PNG error body). The metadata itself is valid — only the artwork is missing.

## Fix

Wrap the HTTP request in `fetchCover()` with a `try/catch` on `ClientRequestException`. On a 404 response:
- Log a warning with the series title and status code
- Return `null` (metadata is returned without a cover)

Any other HTTP error is re-thrown as before.

This mirrors the existing pattern in `ComicVineMetadataProvider.getCover()`, which already handles 404s this way.

## Before / After

**Before:**
```
Fetch metadata ✅ → Fetch cover image → 404 → uncaught exception → entire identify fails ❌
```

**After:**
```
Fetch metadata ✅ → Fetch cover image → 404 → warn + return null → metadata returned without cover ✅
```

## Notes

- Other providers (`AniList`, `BookWalker`, `Bangumi`, `MAL`) have similar unguarded image fetches, but that's out of scope for this PR. This change targets the immediate reported issue.
- `getSeriesCover()` is also protected by this fix, so a standalone cover refresh on a broken URL will also fail gracefully.