### PR TITLE
Fix Automatic Detection of Kavita Volumes/Chapters

### DIFF
--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt
@@ -100,14 +100,19 @@ class KavitaEventHandler(
     }
 
     private fun processProgressNotification(notification: NotificationProgressEvent) {
-        if (notification.name == "ScanProgress" && notification.eventType == "ended") {
-            val now = clock.now()
-            val lastScan = this.lastScan
-            lock.withLock {
-                val volumes = volumesChanged.toList()
-                eventHandlerScope.launch { processEvents(volumes, lastScan) }
-                volumesChanged.clear()
-                this.lastScan = now
+        if (notification.name == "ScanProgress") {
+            when (notification.eventType) {
+                "started" -> {
+                    lock.withLock { this.lastScan = clock.now() }
+                }
+                "ended" -> {
+                    lock.withLock {
+                        val volumes = volumesChanged.toList()
+                        val lastScan = this.lastScan
+                        eventHandlerScope.launch { processEvents(volumes, lastScan) }
+                        volumesChanged.clear()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This fix addresses #275.

Currently `lastScan` time is set once `notification.eventType = "ended"` is received from Kavita message hub. 

This causes the `.filter` in the `processEvents` block of `KavitaEventHandler` to filter out all volumes as `lastScan` time will always be greater then `createdUtc` of the `KavitaVolume`.

https://github.com/Snd-R/komf/blob/5d0f689dc9832056e669e60f41dd8f01d7b275fe/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt#L133-L138

With the fix `lastScan` is set when `notifcation.eventType = "started"` is received.

Old:
<img width="1855" height="942" alt="image" src="https://github.com/user-attachments/assets/8db55cbd-4a30-4ed1-89a5-5f8dd2de63de" />

Patched:
<img width="1944" height="759" alt="image" src="https://github.com/user-attachments/assets/2cd6cd3f-d37b-49dc-9d47-0fd15e3aa2f9" />
