### PR TITLE
fix: register noop handlers for missing Kavita SignalR events

### DIFF
--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt
@@ -181,5 +181,7 @@ class KavitaEventHandler(
         hubConnection.on("UserUpdate", { }, Object::class.java)
         hubConnection.on("UserProgressUpdate", { }, Object::class.java)
         hubConnection.on("WordCountAnalyzerProgress", { }, Object::class.java)
+        hubConnection.on("ReadingSessionUpdate", { }, Object::class.java)
+        hubConnection.on("ReadingSessionClose", { }, Object::class.java)
     }
 }

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaEventHandler.kt
@@ -20,6 +20,7 @@ import snd.komf.mediaserver.BookEvent
 import snd.komf.mediaserver.MediaServerEventListener
 import snd.komf.mediaserver.SeriesEvent
 import snd.komf.mediaserver.kavita.model.KavitaVolumeId
+import snd.komf.mediaserver.kavita.model.events.ChapterUpdatedEvent
 import snd.komf.mediaserver.kavita.model.events.CoverUpdateEvent
 import snd.komf.mediaserver.kavita.model.events.NotificationProgressEvent
 import snd.komf.mediaserver.kavita.model.events.SeriesRemovedEvent
@@ -172,6 +173,7 @@ class KavitaEventHandler(
         hubConnection.on("ScanSeries", { }, Object::class.java)
         hubConnection.on("ScanProgress", { }, Object::class.java)
         hubConnection.on("SendingToDevice", { }, Object::class.java)
+        hubConnection.on("ChapterUpdated", { _: ChapterUpdatedEvent -> }, ChapterUpdatedEvent::class.java)
         hubConnection.on("SeriesAdded", { }, Object::class.java)
         hubConnection.on("SeriesAddedToCollection", { }, Object::class.java)
         hubConnection.on("SiteThemeProgress", { }, Object::class.java)

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/model/events/ChapterUpdatedEvent.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/model/events/ChapterUpdatedEvent.kt
@@ -1,0 +1,16 @@
+package snd.komf.mediaserver.kavita.model.events
+
+data class ChapterUpdatedEvent(
+    val body: Body,
+    val name: String?,
+    val title: String?,
+    val subTitle: String?,
+    val eventType: String?,
+    val progress: String?,
+) {
+
+    data class Body(
+        val seriesId: Int,
+        val chapterId: Int,
+    )
+}


### PR DESCRIPTION
Kavita's SignalR hub sends several events that Komf has no handler registered for. The Microsoft SignalR client logs errors on every occurrence:

```
WARN:  Failed to find handler for 'ChapterUpdated' method.
ERROR: Failed to bind arguments received in invocation 'null' of
       'ChapterUpdated'. Invocation provides 1 argument(s) but
       target expects 0.
```

No functional impact — REST API metadata updates still succeed — but the errors pollute logs continuously.

Fixes #314

**Changes:**
- Add `ChapterUpdatedEvent` model matching Kavita's payload (`SeriesId: Int`, `ChapterId: Int`) following the existing event model pattern
- Register a noop handler for `ChapterUpdated` in `registerInvocations()` in `KavitaEventHandler`
- Register noop handlers for `ReadingSessionUpdate` and `ReadingSessionClose` which have the same issue


Complementary to #309, no compatibility issues.