### PR TITLE
fix: graceful per-provider failure handling

### DIFF
--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataService.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataService.kt
@@ -70,14 +70,32 @@ class MetadataService(
         val providers = metadataProviders.providers(libraryId.value)
 
         return providers
-            .map { coroutineScope.async { it.searchSeries(seriesName) } }
+            .map { provider ->
+                coroutineScope.async {
+                    try {
+                        provider.searchSeries(seriesName)
+                    } catch (e: Exception) {
+                        logger.error(e) { "search failed for provider ${provider.providerName()}" }
+                        emptyList()
+                    }
+                }
+            }
             .flatMap { it.await() }
     }
 
     suspend fun searchSeriesMetadata(seriesName: String): Collection<SeriesSearchResult> {
         val providers = metadataProviders.defaultProvidersList()
         return providers
-            .map { coroutineScope.async { it.searchSeries(seriesName) } }
+            .map { provider ->
+                coroutineScope.async {
+                    try {
+                        provider.searchSeries(seriesName)
+                    } catch (e: Exception) {
+                        logger.error(e) { "search failed for provider ${provider.providerName()}" }
+                        emptyList()
+                    }
+                }
+            }
             .flatMap { it.await() }
     }
 
@@ -231,7 +249,9 @@ class MetadataService(
             val result = try {
                 provider.matchSeriesMetadata(createMatchQuery(searchTitle, series, books))
             } catch (e: Exception) {
-                throw ProviderException(provider.providerName(), e)
+                logger.error(e) { "match failed for provider ${provider.providerName()}" }
+                eventFlow.emit(ProviderErrorEvent(provider.providerName(), "${e::class.simpleName}: ${e.message}"))
+                null
             }
 
             if (result != null) {
@@ -268,7 +288,8 @@ class MetadataService(
             }.toMap()
 
         } catch (e: Exception) {
-            throw ProviderException(provider.providerName(), e)
+            logger.error(e) { "book metadata fetch failed for provider ${provider.providerName()}" }
+            metadataMatch.mapValues { it.value?.let { null } }
         }
     }
 
@@ -333,17 +354,22 @@ class MetadataService(
         return providers
             .map { provider ->
                 coroutineScope.async {
-                    matchSeries(
-                        series = series,
-                        books = books,
-                        searchTitles = searchTitles,
-                        provider = provider,
-                        bookEdition = edition,
-                        eventFlow = eventFlow
-                    ).also {
-                        eventFlow.emit(ProviderCompletedEvent(provider.providerName()))
+                    try {
+                        matchSeries(
+                            series = series,
+                            books = books,
+                            searchTitles = searchTitles,
+                            provider = provider,
+                            bookEdition = edition,
+                            eventFlow = eventFlow
+                        ).also {
+                            eventFlow.emit(ProviderCompletedEvent(provider.providerName()))
+                        }
+                    } catch (e: Exception) {
+                        logger.error(e) { "aggregation failed for provider ${provider.providerName()}" }
+                        eventFlow.emit(ProviderErrorEvent(provider.providerName(), "${e::class.simpleName}: ${e.message}"))
+                        null
                     }
-
                 }
             }
             .mapNotNull { it.await() }


### PR DESCRIPTION
When a metadata provider fails (403, 500, timeout, Cloudflare block), the error is now caught and logged for that provider only. The search, match, and aggregation operations continue with remaining providers instead of aborting the entire operation with a 500 error.

## Problem

When any single provider throws an exception (e.g. BookWalker returns 403 from Cloudflare, AniList rate-limits with 403, MangaUpdates image server 500s), the entire metadata operation aborts and returns a 500 error to the UI. This happens even when the failed provider is not the one being used for identification.

Fixes #216

## Changes

Patched `MetadataService.kt` in 4 places:

1. **`searchSeriesMetadata`** (both overloads): Wrapped each provider async call in try/catch. Failed providers return empty results instead of propagating the exception.

2. **`matchSeries`**: Changed from `throw ProviderException` to log the error, emit a `ProviderErrorEvent`, and return null. This allows the `firstNotNullOfOrNull` loop to continue to the next provider.

3. **`getBookMetadata`**: Changed from `throw ProviderException` to log and return partial metadata (null for failed books) instead of aborting.

4. **`aggregateMetadataFromProviders`**: Wrapped each provider async call in try/catch. Failed providers are skipped instead of crashing the aggregation.

## Testing

Built and deployed on a live Komga instance. BookWalker (Cloudflare-blocked, 403) and AniList (rate-limited, 403) now fail gracefully. Search returns 200 OK with results from remaining providers (VIZ, MangaUpdates, MangaDex, YenPress). No 500 errors.