### PR TITLE
fix(cv): make version field optional in ComicVineSearchResult

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/model/ComicVineSearchResult.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/model/ComicVineSearchResult.kt
@@ -15,6 +15,6 @@ class ComicVineSearchResult<T>(
     @SerialName("status_code")
     val statusCode: Int,
     val results: T,
-    val version: String,
+    val version: String? = null,
 )
 


### PR DESCRIPTION
## Fix
ComicVine's API stopped including the `version` field in search responses, causing `kotlinx.serialization.MissingFieldException`:

Every search request returns HTTP 200 but fails to deserialize, so all ComicVine metadata matching silently breaks.

## Change
Made the `version` field nullable with a default value (`String? = null`) so the serializer gracefully handles responses missing the field.

## Testing
Verified against live ComicVine API — after the fix, search results deserialize correctly even when the `version` field is absent.

Closes #... (no matching issue found)