### PR TITLE
update mangabaka links from .dev to .org

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaMetadataMapper.kt
@@ -91,7 +91,7 @@ class MangaBakaMetadataMapper(
                 link.startsWith("https://myanimelist.net") -> WebLink("MyAnimeList", link)
                 link.startsWith("https://www.anime-planet.com") -> WebLink("Anime-Planet", link)
                 link.startsWith("https://www.novelupdates.com") -> WebLink("NovelUpdates", link)
-                link.startsWith("https://mangabaka.dev") -> WebLink("MangaBaka", link)
+                link.startsWith("https://mangabaka.org") -> WebLink("MangaBaka", link)
                 else -> parseUrl(link)?.let { url -> WebLink(url.host.removePrefix("www."), url.toStingEncoded()) }
             }
         }.sortedBy { it.label }

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/MangaBakaSeries.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.time.Instant
 
-private const val baseUrl = "https://mangabaka.dev"
+private const val baseUrl = "https://mangabaka.org"
 
 @JvmInline
 @Serializable

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/api/MangaBakaApiClient.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/api/MangaBakaApiClient.kt
@@ -10,7 +10,7 @@ import snd.komf.providers.mangabaka.MangaBakaSeriesId
 import snd.komf.providers.mangabaka.MangaBakaType
 
 class MangaBakaApiClient(private val ktor: HttpClient) : MangaBakaDataSource {
-    private val baseUrl = "https://api.mangabaka.dev"
+    private val baseUrl = "https://api.mangabaka.org"
 
     override suspend fun search(title: String, types: List<MangaBakaType>?): List<MangaBakaSeries> {
         return ktor.get("${baseUrl}/v1/series/search") {

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/db/MangaBakaDbDownloader.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangabaka/db/MangaBakaDbDownloader.kt
@@ -45,8 +45,8 @@ class MangaBakaDbDownloader(
     private val dbMetadata: MangaBakaDbMetadata,
     private val onStateRefresh: suspend () -> Unit,
 ) {
-    private val databaseUrl = "https://api.mangabaka.dev/v1/database/series.sqlite.tar.gz"
-    private val checksumUrl = "https://api.mangabaka.dev/v1/database/series.sqlite.tar.gz.sha1"
+    private val databaseUrl = "https://api.mangabaka.org/v1/database/series.sqlite.tar.gz"
+    private val checksumUrl = "https://api.mangabaka.org/v1/database/series.sqlite.tar.gz.sha1"
 
     private val progressFlow = MutableSharedFlow<MangaBakaDownloadProgress>(
         replay = 1,


### PR DESCRIPTION
.dev domain for mangabaka is being depreciated, updating code to .org domain