### PR TITLE
Ensure consistent selection of cover language for MangaDex provider

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangadex/MangaDexMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangadex/MangaDexMetadataMapper.kt
@@ -206,6 +206,7 @@ class MangaDexMetadataMapper(
 
         val books = covers
             .filter { it.attributes.locale in coverLanguages }
+            .sortedBy { coverLanguages.indexOf(it.attributes.locale) }
             .groupBy { it.attributes.volume }.values
             .map { coverArtToBook(it.first()) }
 


### PR DESCRIPTION
Fixing #323 to ensure that order of languages is considered when selecting cover art for the volume 