### PR TITLE
Fix komf-client to support subpath-mounted domains

### DIFF
--- a/komf-client/src/commonMain/kotlin/snd/komf/client/KomfClientFactory.kt
+++ b/komf-client/src/commonMain/kotlin/snd/komf/client/KomfClientFactory.kt
@@ -29,7 +29,7 @@ class KomfClientFactory private constructor(private val builder: Builder) {
     private val ktor: HttpClient = (builder.ktor ?: HttpClient()).config {
         expectSuccess = true
         builder.cookieStorage?.let { install(HttpCookies) { storage = it } }
-        defaultRequest { url(baseUrl()) }
+        defaultRequest { url(baseUrl().trimEnd('/') + "/") }
         install(ContentNegotiation) { json(json) }
         install(SSE)
     }

--- a/komf-client/src/commonMain/kotlin/snd/komf/client/KomfConfigClient.kt
+++ b/komf-client/src/commonMain/kotlin/snd/komf/client/KomfConfigClient.kt
@@ -25,11 +25,11 @@ class KomfConfigClient(
 ) {
 
     suspend fun getConfig(): KomfConfig {
-        return ktor.get("/api/config").body()
+        return ktor.get("api/config").body()
     }
 
     suspend fun updateConfig(request: KomfConfigUpdateRequest) {
-        ktor.patch("/api/config") {
+        ktor.patch("api/config") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }
@@ -38,7 +38,7 @@ class KomfConfigClient(
     fun updateMangaBakaDb(): Flow<MangaBakaDownloadProgress> {
         return flow {
             runCatching {
-                ktor.preparePost("/api/update-manga-baka-db").execute { response ->
+                ktor.preparePost("api/update-manga-baka-db").execute { response ->
                     val channel = response.bodyAsChannel()
                     while (!channel.isClosedForRead) {
                         val message = channel.readUTF8Line()

--- a/komf-client/src/commonMain/kotlin/snd/komf/client/KomfJobClient.kt
+++ b/komf-client/src/commonMain/kotlin/snd/komf/client/KomfJobClient.kt
@@ -32,7 +32,7 @@ class KomfJobClient(
 ) {
 
     suspend fun getJob(jobId: KomfMetadataJobId): KomfMetadataJob {
-        return ktor.get("/api/jobs/$jobId").body()
+        return ktor.get("api/jobs/$jobId").body()
     }
 
     suspend fun getJobs(
@@ -40,7 +40,7 @@ class KomfJobClient(
         page: Int? = null,
         pageSize: Int? = null,
     ): KomfPage<List<KomfMetadataJob>> {
-        return ktor.get("/api/jobs") {
+        return ktor.get("api/jobs") {
             status?.let { parameter("status", status.name) }
             page?.let { parameter("page", page) }
             pageSize?.let { parameter("pageSize", pageSize) }
@@ -48,12 +48,12 @@ class KomfJobClient(
     }
 
     suspend fun getJobEvents(jobId: KomfMetadataJobId): Flow<KomfMetadataJobEvent> {
-        return ktor.sseSession("/api/jobs/${jobId.value}/events").incoming
+        return ktor.sseSession("api/jobs/${jobId.value}/events").incoming
             .map { json.toKomfEvent(it.event, it.data) }
     }
 
     suspend fun deleteAll() {
-        ktor.delete("/api/jobs/all")
+        ktor.delete("api/jobs/all")
     }
 
 

--- a/komf-client/src/commonMain/kotlin/snd/komf/client/KomfMediaServerClient.kt
+++ b/komf-client/src/commonMain/kotlin/snd/komf/client/KomfMediaServerClient.kt
@@ -11,7 +11,7 @@ class KomfMediaServerClient(
     private val ktor: HttpClient,
     mediaServer: MediaServer
 ) {
-    private val mediaServerApiPrefix = "/api/${mediaServer.name.lowercase()}/media-server"
+    private val mediaServerApiPrefix = "api/${mediaServer.name.lowercase()}/media-server"
 
     suspend fun checkConnection(): KomfMediaServerConnectionResponse {
         return ktor.get("$mediaServerApiPrefix/connected").body()

--- a/komf-client/src/commonMain/kotlin/snd/komf/client/KomfMetadataClient.kt
+++ b/komf-client/src/commonMain/kotlin/snd/komf/client/KomfMetadataClient.kt
@@ -20,10 +20,10 @@ class KomfMetadataClient(
     private val ktor: HttpClient,
     mediaServer: MediaServer
 ) {
-    private val metadataApiPrefix = "/api/${mediaServer.name.lowercase()}/metadata"
+    private val metadataApiPrefix = "api/${mediaServer.name.lowercase()}/metadata"
 
     suspend fun getProviders(): List<String> {
-        return ktor.get("/api/metadata/providers").body()
+        return ktor.get("api/metadata/providers").body()
     }
 
     suspend fun searchSeries(

--- a/komf-client/src/commonMain/kotlin/snd/komf/client/KomfNotificationClient.kt
+++ b/komf-client/src/commonMain/kotlin/snd/komf/client/KomfNotificationClient.kt
@@ -15,25 +15,25 @@ class KomfNotificationClient(
     private val ktor: HttpClient,
 ) {
     suspend fun getDiscordTemplates(): KomfDiscordTemplates {
-        return ktor.get("/api/notifications/discord/templates").body()
+        return ktor.get("api/notifications/discord/templates").body()
     }
 
     suspend fun updateDiscordTemplates(templates: KomfDiscordTemplates): KomfDiscordTemplates {
-        return ktor.post("/api/notifications/discord/templates") {
+        return ktor.post("api/notifications/discord/templates") {
             contentType(ContentType.Application.Json)
             setBody(templates)
         }.body()
     }
 
     suspend fun renderDiscord(request: KomfDiscordRequest): KomfDiscordRenderResult {
-        return ktor.post("/api/notifications/discord/render") {
+        return ktor.post("api/notifications/discord/render") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }.body()
     }
 
     suspend fun sendDiscord(request: KomfDiscordRequest) {
-        ktor.post("/api/notifications/discord/send") {
+        ktor.post("api/notifications/discord/send") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }
@@ -41,25 +41,25 @@ class KomfNotificationClient(
 
 
     suspend fun getAppriseTemplates(): KomfAppriseTemplates {
-        return ktor.get("/api/notifications/apprise/templates").body()
+        return ktor.get("api/notifications/apprise/templates").body()
     }
 
     suspend fun updateAppriseTemplates(templates: KomfAppriseTemplates): KomfAppriseTemplates {
-        return ktor.post("/api/notifications/apprise/templates") {
+        return ktor.post("api/notifications/apprise/templates") {
             contentType(ContentType.Application.Json)
             setBody(templates)
         }.body()
     }
 
     suspend fun renderApprise(request: KomfAppriseRequest): KomfAppriseRenderResult {
-        return ktor.post("/api/notifications/apprise/render") {
+        return ktor.post("api/notifications/apprise/render") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }.body()
     }
 
     suspend fun sendApprise(request: KomfAppriseRequest) {
-        ktor.post("/api/notifications/apprise/send") {
+        ktor.post("api/notifications/apprise/send") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }


### PR DESCRIPTION
## Summary
- Normalize the base URL in `KomfClientFactory` to always end with a single trailing slash, and switch every `komf-client` request from an absolute path (`"/api/..."`) to a relative one (`"api/..."`). Ktor treats a leading `/` as "replace the whole path from the host root," which silently discards any subpath in the base URL (e.g. `https://host/komf/`), so this was breaking any deployment reverse-proxied under a subpath.
- Fixed `KomfNotificationClient`, which had drifted from the pattern used in the other client files — it dropped the `api` segment while keeping the leading slash, so its 8 endpoints (`getDiscordTemplates`, `updateDiscordTemplates`, `renderDiscord`, `sendDiscord`, and the Apprise equivalents) pointed at nonexistent routes. Verified against the actual server routing in `ServerModule.kt` / `NotificationRoutes.kt` and corrected to `api/notifications/...`.

## Test plan
- [x] `./gradlew :komf-client:compileKotlinJvm` — compiles clean
- [x] `./gradlew :komf-app:compileKotlin` — compiles clean
- [ ] Manual verification against a server actually reverse-proxied under a subpath (not tested here)