### PR TITLE
Isolate provider search failures instead of failing the whole request

### DIFF
--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataService.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataService.kt
@@ -68,17 +68,25 @@ class MetadataService(
         libraryId: MediaServerLibraryId
     ): Collection<SeriesSearchResult> {
         val providers = metadataProviders.providers(libraryId.value)
-
-        return providers
-            .map { coroutineScope.async { it.searchSeries(seriesName) } }
-            .flatMap { it.await() }
+        return searchSeriesMetadata(seriesName, providers)
     }
 
     suspend fun searchSeriesMetadata(seriesName: String): Collection<SeriesSearchResult> {
         val providers = metadataProviders.defaultProvidersList()
+        return searchSeriesMetadata(seriesName, providers)
+    }
+
+    private suspend fun searchSeriesMetadata(
+        seriesName: String,
+        providers: Collection<MetadataProvider>
+    ): Collection<SeriesSearchResult> {
         return providers
-            .map { coroutineScope.async { it.searchSeries(seriesName) } }
-            .flatMap { it.await() }
+            .map { provider -> provider to coroutineScope.async { provider.searchSeries(seriesName) } }
+            .flatMap { (provider, deferred) ->
+                runCatching { deferred.await() }
+                    .onFailure { e -> logger.error(e) { "search failed for provider ${provider.providerName()}" } }
+                    .getOrDefault(emptyList())
+            }
     }
 
     suspend fun getSeriesCover(


### PR DESCRIPTION
## Summary
- `MetadataService.searchSeriesMetadata` launched each provider's search concurrently but awaited them without catching per-provider errors, so one failing provider (e.g. a 403 from a scraping-blocked source) would throw and discard results from every other provider that had already succeeded — surfacing as a 500 to callers even though most providers returned fine.
- Each provider's result is now caught individually and logged on failure, contributing only its own results to the aggregate instead of aborting the whole search.

Fixes #216 (at least for the manual/plain search path; the job-based auto-match flow has its own separate error handling in the same file that could use a similar treatment if useful).

## Test plan
- [x] `./gradlew :komf-mediaserver:compileKotlinJvm` builds clean
- [x] Reproduced the original failure mode locally: one provider (BookWalker) returning 403 while others (Viz, AniList, YenPress, MangaUpdates) returned 200 caused the whole search to fail before this change